### PR TITLE
Receiver gates and symbol hygiene

### DIFF
--- a/docs/src/mlir.md
+++ b/docs/src/mlir.md
@@ -275,8 +275,12 @@ generalization, and the lowering reads data and strides only.
 
 ## 6. The ops
 
-Fourteen ops. Liveness is tracked deliberately, because "defined in TableGen" and
-"something emits it" are different claims:
+Fourteen ops, **all fourteen with a producer** as of 2026-08-13. Liveness is
+tracked deliberately, because "defined in TableGen" and "something emits it" are
+different claims — and it is checked mechanically rather than asserted here, by
+`test_jlcs_invariants.jl` §E, which reads the mnemonics out of `JLCSOps.td`,
+greps `src/` for emission, and fails naming any op whose tier moved. That guard
+exists because this table was wrong for months (see below).
 
 | Op | Producer | Verifier | Role |
 |---|---|---|---|
@@ -288,19 +292,56 @@ Fourteen ops. Liveness is tracked deliberately, because "defined in TableGen" an
 | `jlcs.marshal_ret` | `FunctionGen` | — | C-packed struct value → Julia-aligned struct value |
 | `jlcs.scope` | `FunctionGen` | ✅ | RAII region; destructors fire in reverse at exit |
 | `jlcs.ctor_call` | `FunctionGen` | — | constructor on an object pointer |
-| `jlcs.dtor_call` | `FunctionGen` | — | destructor on an object pointer (exactly one operand) |
+| `jlcs.dtor_call` | `FunctionGen` | ✅ | destructor on an object pointer (exactly one operand) |
 | `jlcs.yield` | `FunctionGen` | — | `jlcs.scope` terminator |
 | `jlcs.load_array_element` | `ArrayViewGen` | — | strided read through an `!jlcs.array_view` |
 | `jlcs.store_array_element` | `ArrayViewGen` | — | strided write |
-| `jlcs.get_field` | **none** | — | generic struct field read by byte offset |
-| `jlcs.set_field` | **none** | — | generic struct field write by byte offset |
+| `jlcs.get_field` | `FunctionGen`, `ArrayViewGen` | ✅ | field read by byte offset |
+| `jlcs.set_field` | `ArrayViewGen` | ✅ | field write by byte offset |
 
-`get_field` / `set_field` are defined, lowered, and exercised **only by
-hand-written test IR** (`test_mlir_templates.jl` §3 and §10). Nothing under
-`src/` emits them: the producers address members with `llvm.getelementptr`
-directly. This is a claim about producers, not about coverage — the fixtures
-that drive real generated wrappers (`mi_test`, `vi_test`, `stl_test`) all reach
-the JIT through `FunctionGen`/`ArrayViewGen`.
+### How the last three got producers
+
+Until 2026-08-13 the bottom three rows read `none`, and one of them read `none`
+without saying so. `jlcs.dtor_call` was credited to `FunctionGen` here and in
+the internal devlog for months while nothing emitted it: the scope-RAII producer
+builds `jlcs.scope(...) dtors([@sym, ...])`, and it is the *scope's* lowering
+that emits those calls (as `LLVM::CallOp`, directly), so `DestructorCallOp` had
+a registered and unreachable conversion pattern. The pairing with `ctor_call` —
+which does have a producer — is what made the gap read as symmetry.
+
+- **`dtor_call`** — a destructor thunk is exactly this op's shape: one object
+  pointer in, void out. It used to go out as a generic `ffe_call`/`try_call`
+  with the full SysV coercion machinery attached to a signature that needs
+  none. The op gained a `may_throw` unit attribute (mirroring `vcall`'s) with
+  an invoke + landing-pad lowering, so a thunk moving onto it keeps the exact
+  EH semantics it had — DWARF marks no destructor `noexcept`, so in practice
+  C++ destructor thunks take the EH path.
+
+  The **arity gate is load-bearing**: under Itanium a base-object destructor
+  (`D2`) of a class with virtual bases takes a second VTT argument, and this op
+  has no operand to carry it. `vi_test` has three (`_ZN4LeftD2Ev(this, vtt)`).
+  Those keep the `ffe_call`/`try_call` path; converting them would drop the VTT
+  silently. The gate reads the *final* argument list, after `this` synthesis,
+  not the DWARF parameter list.
+
+- **`get_field` / `set_field`** — the thunk argument array is a record with a
+  fixed layout: the ciface convention hands the thunk a `void**`, so reading
+  argument slot `i` is a field read at byte offset `8i`. That is what both
+  producers now say, in one op, instead of a constant plus a pointer-scaled GEP
+  plus a load. `ArrayViewGen` additionally builds the `!jlcs.array_view`
+  descriptor with one `set_field` per field (data@0, dims@8, strides@16,
+  rank@24) — the same terms the array-op lowering reads it back in, which
+  previously was a GEP chain on the producer side and byte offsets on the
+  consumer side with nothing tying them together.
+
+This changes what the IR *says*, not what it *does*, and that is checked rather
+than asserted: every function of `mi_test`, `vi_test` and `stl_test` (188
+symbols) compiles to byte-identical machine code across the switch, and
+`test_jlcs_producers.jl` §G pins the per-shape equivalence directly. The
+motivation is that the `.mlir` is the debugger's source file (see *Debugging*
+below) — `jlcs.get_field ... {fieldOffset = 8}` is what gdb shows at the
+breakpoint, and the argument-slot convention it encodes is the one this
+project's notes record as having cost a debugging session.
 
 ### Metadata: `type_info`
 
@@ -627,8 +668,6 @@ not that marshalling be right, it is that wrong marshalling be *loud*.
 
 Deliberately unbuilt, so they are not chased as bugs:
 
-- **`get_field` / `set_field` have no producer.** Defined and lowered; only
-  hand-written test IR drives them.
 - **Array views are rank 1.** The producer's regex skips `T[N][M]`; the
   descriptor's dims/rank fields are populated but unread by the lowering, and
   the user-facing Julia accessors that would call these thunks are not emitted
@@ -636,9 +675,12 @@ Deliberately unbuilt, so they are not chased as bugs:
 - **`vcall` gates on scalar/pointer signatures.** Virtual methods returning a
   struct by value or taking a packed struct by value keep the direct-call path;
   closing this means giving the vcall lowering `try_call`'s coercion.
-- **Ten ops have no verifier** (`ffe_call`, `try_call`, `get_field`, `set_field`,
-  `load/store_array_element`, `ctor_call`, `dtor_call`, `yield`, `marshal_ret`).
-  No known crash paths, but hand-written IR gets no schema help.
+- **Seven ops have no verifier** (`ffe_call`, `try_call`,
+  `load/store_array_element`, `ctor_call`, `yield`, `marshal_ret`). No known
+  crash paths, but hand-written IR gets no schema help. `get_field`,
+  `set_field` and `dtor_call` gained theirs on 2026-08-13 with their producers
+  — all three lowerings take a pointer operand on faith, which ODS's `AnyType`
+  accepts and LLVM translation then rejects far from the mistake.
 - **The classifier is x86-64 SysV only.** The 16-byte MEMORY threshold, 64-bit
   pointers, and i64/f64 eightbytes are hardcoded. Win64 and AAPCS are not
   modeled.

--- a/src/Builder/Compiler.jl
+++ b/src/Builder/Compiler.jl
@@ -2027,6 +2027,30 @@ function extract_symbols_from_binary(binary_path::String)
                     continue
                 end
 
+                # Itanium adjustor thunks are vtable-slot entry points, not API:
+                # they fix up `this` on entry (a fixed subtraction, or a vcall
+                # offset read through the vptr) and tail-jump to the real method.
+                # Nothing should reach one BY NAME — an override is reached
+                # through the vtable (the vcall producer) or after an explicit
+                # upcast (`Derived_as_Base2`).
+                #
+                # Same reasoning as `__rb_*` above, and the same failure: no
+                # DWARF subprogram describes a thunk, so `parse_function_signatures`
+                # infers the signature from the demangled string — where the
+                # "class" is the demangler's PHRASE ("non-virtual thunk to
+                # Derived"), not a class name. No aggregate is named that, so
+                # neither receiver gate (`FunctionGen._has_receiver`,
+                # `GeneratorCpp`'s `struct_types` check) synthesizes `this`, and
+                # the wrapper emits a zero-argument function calling a method that
+                # needs `this` in rdi. Proven live 2026-08-13, not latent:
+                # `ViTest.virtual_thunk_to_Diamond_tag()` was exported and
+                # SIGSEGV'd — the virtual-thunk form dereferences the garbage
+                # `this` twice (`mov (%rdi),%rax; mov -0x20(%rax),%rax`) to read
+                # the vcall offset out of the vptr.
+                if _is_itanium_thunk(mangled_name, demangled_name)
+                    continue
+                end
+
                 push!(symbols, Dict(
                     "mangled" => mangled_name,
                     "demangled" => demangled_name,
@@ -2038,6 +2062,33 @@ function extract_symbols_from_binary(binary_path::String)
     end
 
     return symbols
+end
+
+"""
+    _is_itanium_thunk(mangled, demangled) -> Bool
+
+Return true for Itanium ABI thunk symbols — `_ZTh` (non-virtual / this-adjusting),
+`_ZTv` (virtual), `_ZTc` (covariant return).
+
+These belong to the mangling grammar's `<special-name>` production, so a `_ZT`
+prefix can never collide with an ordinary function; the remaining `_ZT*` special
+names (`_ZTV` vtable, `_ZTI`/`_ZTS` typeinfo, `_ZTT` VTT, `_ZTC` construction
+vtable) are **data** symbols and never reach this filter — the caller admits only
+nm types `T`/`W`/`t`/`w`. Verified against the MI and VI fixtures: every `_ZT*`
+symbol with a code type is a thunk, and every vtable/typeinfo one is `D`/`R`/`V`.
+
+The demangled phrases are checked as well because the caller falls back to the
+demangled string when the address→mangled lookup misses, and because an ingested
+binary may be stripped of the mangled form.
+"""
+function _is_itanium_thunk(mangled::AbstractString, demangled::AbstractString)::Bool
+    startswith(mangled, "_ZTh") && return true    # non-virtual thunk to X
+    startswith(mangled, "_ZTv") && return true    # virtual thunk to X
+    startswith(mangled, "_ZTc") && return true    # covariant return thunk to X
+    startswith(demangled, "non-virtual thunk to ") && return true
+    startswith(demangled, "virtual thunk to ") && return true
+    startswith(demangled, "covariant return thunk to ") && return true
+    return false
 end
 
 """
@@ -4676,25 +4727,110 @@ function _name_prefix(demangled::String)::String
 end
 
 """
+    _strip_return_type(prefix) -> String
+
+Drop a leading return type from a demangled function-name prefix:
+`"bool gguf_reader::read<int>"` → `"gguf_reader::read<int>"`.
+
+Itanium mangles a function **template's** return type into the symbol, so the
+demangler prints it — ordinary functions carry none. The return type ends at the
+last space outside `<>`/`()`, which is enough even when it is itself qualified
+(`std::enable_if<std::is_integral<unsigned int>::value, bool>::type`).
+
+A **conversion operator** is the only C++ name that legitimately contains a
+top-level space (`operator bool`, `operator void (*)(…)`, `operator new`), and
+cutting at its space would eat the name. Those bail out unchanged, so the result
+is the historical behaviour rather than a new wrong answer — pugixml has 7.
+"""
+function _strip_return_type(prefix::AbstractString)::String
+    occursin("operator", prefix) && return String(prefix)
+    depth = 0
+    cut = 0
+    i = firstindex(prefix)
+    n = lastindex(prefix)
+    while i <= n
+        c = prefix[i]
+        if c == '<' || c == '('
+            depth += 1
+        elseif c == '>' || c == ')'
+            depth = max(0, depth - 1)
+        elseif depth == 0 && c == ' '
+            cut = i
+        end
+        i = nextind(prefix, i)
+    end
+    cut == 0 && return String(prefix)
+    return String(strip(prefix[nextind(prefix, cut):end]))
+end
+
+"""
+    _qualified_name_parts(demangled) -> Vector{String}
+
+The `::`-separated components of a demangled signature's qualified name, with any
+leading return type removed and template arguments left intact:
+`"bool gguf_reader::read<std::vector<int> >(…)"` → `["gguf_reader", "read<std::vector<int> >"]`.
+
+`extract_class_name` and `extract_function_name` both derive from this one
+function, so they cannot disagree about where the scope ends.
+
+The obvious `split(prefix, "::")` this replaces got two things wrong, both live
+in the Hub until 2026-08-13:
+
+  * **Template arguments contain `::`.** A flat split cuts inside them, so
+    `llama_model_loader::get_arr<std::vector<int, std::allocator<int> > >` yielded
+    class `"bool llama_model_loader::get_arr<std::vector<int, std"` and name
+    `"allocator<int> > >"`. Splitting is angle-bracket- and paren-depth aware
+    (depth clamps at 0 so `operator>` / `operator->` cannot drive it negative).
+
+  * **The return type of a function template.** The scope came out
+    `"bool gguf_reader"`; no aggregate is named that, so neither receiver gate
+    (`FunctionGen._has_receiver`, `GeneratorCpp`'s `struct_types` check)
+    synthesized `this` and every argument shifted one register — the silent
+    direction. Measured: **62 methods gained a receiver, 0 lost one** across
+    box2d (4), llamacpp (48), pugixml (8), tinyxml2 (2).
+"""
+function _qualified_name_parts(demangled::AbstractString)::Vector{String}
+    prefix = _strip_return_type(_name_prefix(String(demangled)))
+    out = String[]
+    depth = 0
+    start = firstindex(prefix)
+    i = start
+    n = lastindex(prefix)
+    while i <= n
+        c = prefix[i]
+        if c == '<' || c == '('
+            depth += 1
+        elseif c == '>' || c == ')'
+            depth = max(0, depth - 1)
+        elseif depth == 0 && c == ':' && i < n && prefix[nextind(prefix, i)] == ':'
+            push!(out, String(prefix[start:prevind(prefix, i)]))
+            i = nextind(prefix, i)
+            start = nextind(prefix, i)
+        end
+        i = nextind(prefix, i)
+    end
+    push!(out, String(prefix[start:end]))
+    return out
+end
+
+"""
 Extract function name from demangled signature.
 Example: "Calculator::compute(int, int, char)" -> "compute"
 Example: "sum_vector(std::vector<int, std::allocator<int> > const&)" -> "sum_vector"
+Example: "bool gguf_reader::read<std::vector<int> >(...)" -> "read<std::vector<int> >"
 """
 function extract_function_name(demangled::String)::String
-    prefix = _name_prefix(demangled)
-    # Split only on '::' within the prefix (safe – no templates here)
-    parts = split(prefix, "::")
-    return strip(parts[end])
+    return String(strip(_qualified_name_parts(demangled)[end]))
 end
 
 """
 Extract class name from method signature (only considers '::' in the function-name prefix).
 Example: "Calculator::compute(int, int)" -> "Calculator"
 Example: "sum_vector(std::vector<int> const&)"  -> ""  (free function)
+Example: "bool gguf_reader::read<int>(...)"     -> "gguf_reader"  (NOT "bool gguf_reader")
 """
 function extract_class_name(demangled::String)::String
-    prefix = _name_prefix(demangled)
-    parts = split(prefix, "::")
+    parts = _qualified_name_parts(demangled)
     length(parts) >= 2 || return ""
     return join(parts[1:end-1], "::")
 end

--- a/src/IRGen/ir_gen/ArrayViewGen.jl
+++ b/src/IRGen/ir_gen/ArrayViewGen.jl
@@ -59,13 +59,11 @@ at the array member (byte offset `member_off`), dims=[n], strides=[1], rank=1.
 function _emit_view_prologue(member_off::Int, n::Int)::String
     io = IOBuffer()
     println(io, "  %one = llvm.mlir.constant(1 : i64) : i64")
-    println(io, "  %i0 = arith.constant 0 : i64")
-    println(io, "  %oslot = llvm.getelementptr %args_ptr[%i0] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.ptr")
-    println(io, "  %optr = llvm.load %oslot : !llvm.ptr -> !llvm.ptr")
+    # Argument slots are fields of the ciface `void**` at byte offset 8*slot —
+    # same op, same reasoning as the FunctionGen prologue.
+    println(io, "  %optr = \"jlcs.get_field\"(%args_ptr) {fieldOffset = 0 : i64} : (!llvm.ptr) -> !llvm.ptr")
     println(io, "  %obj = llvm.load %optr : !llvm.ptr -> !llvm.ptr")
-    println(io, "  %i1 = arith.constant 1 : i64")
-    println(io, "  %islot = llvm.getelementptr %args_ptr[%i1] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.ptr")
-    println(io, "  %iptr = llvm.load %islot : !llvm.ptr -> !llvm.ptr")
+    println(io, "  %iptr = \"jlcs.get_field\"(%args_ptr) {fieldOffset = 8 : i64} : (!llvm.ptr) -> !llvm.ptr")
     println(io, "  %idx64 = llvm.load %iptr : !llvm.ptr -> i64")
     println(io, "  %index = arith.index_cast %idx64 : i64 to index")
     # Data pointer: the array member inside the caller's struct (zero-copy)
@@ -76,15 +74,18 @@ function _emit_view_prologue(member_off::Int, n::Int)::String
     println(io, "  llvm.store %dimval, %dims : i64, !llvm.ptr")
     println(io, "  %strides = llvm.alloca %one x i64 : (i64) -> !llvm.ptr")
     println(io, "  llvm.store %one, %strides : i64, !llvm.ptr")
-    # ArrayView descriptor: data@0, dims@8, strides@16, rank@24
+    # ArrayView descriptor, one jlcs.set_field per field. This is the producer
+    # side of a layout the CONSUMER already reads in exactly these terms: the
+    # load/store_array_element lowering pulls data with getStructField(view, 0)
+    # and strides with getStructField(view, 16). Writing it as a GEP chain here
+    # meant the descriptor's layout was stated twice, in two notations, with
+    # nothing tying them together — the offsets below and the offsets in
+    # JLCSPasses.cpp have to agree, and now they at least agree in form.
     println(io, "  %view = llvm.alloca %one x !llvm.struct<(ptr, ptr, ptr, i64)> : (i64) -> !llvm.ptr")
-    println(io, "  llvm.store %data, %view : !llvm.ptr, !llvm.ptr")
-    println(io, "  %dimsfield = llvm.getelementptr %view[8] : (!llvm.ptr) -> !llvm.ptr, i8")
-    println(io, "  llvm.store %dims, %dimsfield : !llvm.ptr, !llvm.ptr")
-    println(io, "  %stridesfield = llvm.getelementptr %view[16] : (!llvm.ptr) -> !llvm.ptr, i8")
-    println(io, "  llvm.store %strides, %stridesfield : !llvm.ptr, !llvm.ptr")
-    println(io, "  %rankfield = llvm.getelementptr %view[24] : (!llvm.ptr) -> !llvm.ptr, i8")
-    println(io, "  llvm.store %one, %rankfield : i64, !llvm.ptr")
+    println(io, "  \"jlcs.set_field\"(%view, %data) {fieldOffset = 0 : i64} : (!llvm.ptr, !llvm.ptr) -> ()")
+    println(io, "  \"jlcs.set_field\"(%view, %dims) {fieldOffset = 8 : i64} : (!llvm.ptr, !llvm.ptr) -> ()")
+    println(io, "  \"jlcs.set_field\"(%view, %strides) {fieldOffset = 16 : i64} : (!llvm.ptr, !llvm.ptr) -> ()")
+    println(io, "  \"jlcs.set_field\"(%view, %one) {fieldOffset = 24 : i64} : (!llvm.ptr, i64) -> ()")
     return String(take!(io))
 end
 
@@ -164,9 +165,7 @@ function generate_array_view_thunks(structs; needed_symbols=nothing)::String
 
             println(io, "func.func @$(base)_set_thunk(%args_ptr: !llvm.ptr) attributes { llvm.emit_c_interface } {")
             print(io, _emit_view_prologue(off, n))
-            println(io, "  %vidx = arith.constant 2 : i64")
-            println(io, "  %vslot = llvm.getelementptr %args_ptr[%vidx] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.ptr")
-            println(io, "  %vptr = llvm.load %vslot : !llvm.ptr -> !llvm.ptr")
+            println(io, "  %vptr = \"jlcs.get_field\"(%args_ptr) {fieldOffset = 16 : i64} : (!llvm.ptr) -> !llvm.ptr")
             println(io, "  %value = llvm.load %vptr : !llvm.ptr -> $(elt)")
             println(io, "  \"jlcs.store_array_element\"(%value, %view, %index) : ($(elt), !llvm.ptr, index) -> ()")
             println(io, "  return")

--- a/src/IRGen/ir_gen/FunctionGen.jl
+++ b/src/IRGen/ir_gen/FunctionGen.jl
@@ -334,10 +334,22 @@ function generate_function_thunks(functions::Vector, structs::Any=Dict(); may_th
                 end
             end
 
-            idx = i - 1
-            println(io, "  %idx_$(i) = arith.constant $(idx) : i64")
-            println(io, "  %arg_ptr_$(i) = llvm.getelementptr %args_ptr[%idx_$(i)] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.ptr")
-            println(io, "  %val_ptr_$(i) = llvm.load %arg_ptr_$(i) : !llvm.ptr -> !llvm.ptr")
+            # Argument slot read. The ciface convention hands the thunk a
+            # `void**`, so slot i-1 is a field at byte offset 8*(i-1) — which
+            # is what jlcs.get_field says, in one op, instead of a constant
+            # plus a pointer-scaled GEP plus a load. Same address arithmetic:
+            # `getelementptr ptr, ptr %args, i64 N` and
+            # `getelementptr i8, ptr %args, i64 8N` compute the same address,
+            # and the emitted machine code is instruction-identical (proven
+            # per-shape in test_jlcs_producers.jl §E).
+            #
+            # This is the op stating the convention that CLAUDE.md records as
+            # having cost a debugging session: the result is the address of
+            # the argument's STORAGE, so scalars and pointers both need the
+            # second load below. The .mlir is the debugger's source file, so
+            # what is written here is what gdb shows at the breakpoint.
+            slot_off = 8 * (i - 1)
+            println(io, "  %val_ptr_$(i) = \"jlcs.get_field\"(%args_ptr) {fieldOffset = $(slot_off) : i64} : (!llvm.ptr) -> !llvm.ptr")
 
             if !isnothing(raii_specs[i])
                 # Non-trivial by-value param: the temporary is copy-constructed
@@ -394,6 +406,31 @@ function generate_function_thunks(functions::Vector, structs::Any=Dict(); may_th
             use_try_call && (vcall_attrs *= ", may_throw")
         end
 
+        # Destructor thunks: jlcs.dtor_call encodes exactly this shape — one
+        # object pointer in, void out — so the ABI coercion ffe_call/try_call
+        # carry has nothing to do, and the op states in the IR what the symbol
+        # name only implies. Destructor-ness is tested the same way both other
+        # readers of this metadata test it (`~` in the demangled name,
+        # GeneratorCpp.jl:125, JLCSIRGenerator._collect_class_raii).
+        #
+        # The ARITY GATE IS LOAD-BEARING, not defensive: under Itanium a
+        # base-object destructor (D2) of a class with virtual bases takes a
+        # second VTT argument — vi_test has three (`_ZN4LeftD2Ev(this, vtt)`)
+        # — and dtor_call has no operand to carry it. Those keep the
+        # ffe_call/try_call path; emitting dtor_call for them would drop the
+        # VTT silently. Same reason the gate is on the FINAL call_args, after
+        # `this` synthesis, rather than on the DWARF parameter list.
+        #
+        # may_throw comes from the same `may_throw && !is_noexcept` rule that
+        # picks try_call over ffe_call, so a thunk moving onto this op keeps
+        # the landing pad it had. (DWARF marks none of these noexcept, so in
+        # practice C++ destructor thunks land on the EH path.)
+        is_destructor = occursin("~", String(get(func, "demangled", "")))
+        use_dtor_call = is_destructor && !has_raii && !use_vcall &&
+                        func_ret == "" && length(call_args) == 1 &&
+                        length(arg_types) == 1 && arg_types[1] == "!llvm.ptr"
+        dtor_attrs = use_try_call ? " { may_throw }" : ""
+
         # Call using jlcs.ffe_call or jlcs.try_call (via Dialect)
         if has_raii
             # Scope-RAII: copy-construct temporaries, call inside the scope,
@@ -441,6 +478,8 @@ function generate_function_thunks(functions::Vector, structs::Any=Dict(); may_th
              # Void return
              if use_vcall
                  println(io, "  \"jlcs.vcall\"($(join(call_args, ", "))) { $(vcall_attrs) } : ($(join(arg_types, ", "))) -> ()")
+             elseif use_dtor_call
+                 println(io, "  jlcs.dtor_call @$(mangled)($(call_args[1]))$(dtor_attrs) : (!llvm.ptr) -> ()")
              else
                  println(io, "  $(call_op) $(join(call_args, ", ")) { callee = @$(mangled) } : ($(join(arg_types, ", "))) -> ()")
              end

--- a/src/IRGen/ir_gen/FunctionGen.jl
+++ b/src/IRGen/ir_gen/FunctionGen.jl
@@ -48,12 +48,69 @@ check: this gate can only over-admit relative to it, never wrongly deny a real
 method its receiver (the failure that direction is silent argument shifting).
 """
 function _has_receiver(func, structs)::Bool
+    # A constructor or destructor ALWAYS has a receiver — that is a fact about
+    # C++, not an inference from the aggregate table, so it is checked FIRST and
+    # independently. It matters because the table is not a complete list of the
+    # library's classes: a .cpp-local polymorphic class gets no type DIE, so
+    # box2d's internal contact subclasses (`b2CircleContact` and six siblings)
+    # are absent from it and their destructors were emitted as ZERO-ARGUMENT
+    # wrappers — the same shape as the adjustor-thunk bug, found the same day
+    # (2026-08-13) by rebuilding box2d for the first time since Jul 17.
+    _is_ctor_or_dtor(func) && return true
     cls = String(get(func, "class", ""))
     isempty(cls) && return false
     for cand in _scope_suffixes(cls)
         _fuzzy_struct_lookup(cand, structs) !== nothing && return true
     end
     return false
+end
+
+"""
+    _is_ctor_or_dtor(func) -> Bool
+
+True when `func` is a constructor or destructor, from the demangled `class` and
+`name` metadata alone.
+
+**This predicate is duplicated in `GeneratorCpp.jl` and the two copies MUST
+agree** — they decide the same argument array from opposite ends of the
+pipeline, which is the `ffe_call`/`try_call` hazard shape. The duplication is
+deliberate (the generators are isolated on purpose); the protection is
+`test_symbol_hygiene.jl` §"Both receiver gates agree", which drives BOTH gates
+over every Hub package's metadata and fails on any disagreement.
+
+Tests, and why each is safe in the dangerous direction (a false positive
+synthesizes `this` for a free function and shifts every argument):
+
+  * **Destructor** — the name begins with `~`. Nothing else in C++ does. This is
+    the same test `GeneratorCpp.jl`'s deleter scan and `_collect_class_raii`
+    already use, so all readers of this metadata agree.
+  * **Constructor** — the name equals the class's own bare name. A member
+    function may not share its class's name; that IS the constructor, so there
+    is no false positive to have.
+
+Template arguments are stripped from the class before comparing, because the
+demangler prints `Box<int>::Box()` — name `Box`, class `Box<int>`.
+"""
+function _is_ctor_or_dtor(func)::Bool
+    cls   = String(get(func, "class", ""))
+    fname = String(get(func, "name", ""))
+    (isempty(cls) || isempty(fname)) && return false
+    startswith(fname, "~") && return true
+    return fname == _bare_type_name(cls)
+end
+
+"""
+    _bare_type_name(cls) -> String
+
+The innermost `::` component of a scope with template arguments removed:
+`std::vector<int, std::allocator<int> >` → `vector`, `pugi::xml_document` →
+`xml_document`. Splitting is angle-bracket aware (via [`_scope_suffixes`]), so
+a separator inside `<>` is not a cut point.
+"""
+function _bare_type_name(cls::AbstractString)::String
+    inner = last(_scope_suffixes(cls))
+    i = findfirst('<', inner)
+    return String(strip(i === nothing ? inner : inner[1:prevind(inner, i)]))
 end
 
 """

--- a/src/Wrapper/Cpp/GeneratorCpp.jl
+++ b/src/Wrapper/Cpp/GeneratorCpp.jl
@@ -1,3 +1,147 @@
+"""
+    _bare_type_name_cpp(cls) -> String
+
+Innermost `::` component of a scope, template arguments removed:
+`std::vector<int, std::allocator<int> >` → `vector`. Angle-bracket aware, so a
+separator inside `<>` is not a cut point.
+"""
+function _bare_type_name_cpp(cls::AbstractString)::String
+    depth = 0
+    last_sep = 0
+    i = firstindex(cls)
+    n = lastindex(cls)
+    while i <= n
+        c = cls[i]
+        if c == '<'
+            depth += 1
+        elseif c == '>'
+            depth = max(0, depth - 1)
+        elseif depth == 0 && c == ':' && i < n && cls[nextind(cls, i)] == ':'
+            i = nextind(cls, i)
+            last_sep = i
+        end
+        i = nextind(cls, i)
+    end
+    inner = last_sep == 0 ? cls : cls[nextind(cls, last_sep):end]
+    j = findfirst('<', inner)
+    return String(strip(j === nothing ? inner : inner[1:prevind(inner, j)]))
+end
+
+"""
+    _is_ctor_or_dtor_cpp(class_name, func_name) -> Bool
+
+True when the function is a constructor or destructor — which has a `this`
+receiver by definition, whether or not its class reached `struct_types`.
+
+**Mirror of `FunctionGen._is_ctor_or_dtor`; the two MUST agree**, because they
+decide the same argument array from opposite ends of the pipeline. The
+duplication is deliberate (generator isolation); the protection is
+`test_symbol_hygiene.jl` §"Both receiver gates agree", which runs both over
+every Hub package's metadata.
+
+A destructor's name starts with `~`; a constructor's name equals its class's
+bare name, and a member function may not share its class's name — so neither
+test can fire on a free function, which is the direction that would shift
+arguments.
+"""
+function _is_ctor_or_dtor_cpp(class_name::AbstractString, func_name::AbstractString)::Bool
+    (isempty(class_name) || isempty(func_name)) && return false
+    startswith(func_name, "~") && return true
+    return func_name == _bare_type_name_cpp(class_name)
+end
+
+"""
+    _cpp_innermost_scope(cls) -> String
+
+Last `::`-separated component of `cls`, at angle-bracket depth 0, **keeping**
+template arguments: `ggml::cpu::repack::tensor_traits<block_q4_0, 8l>` →
+`tensor_traits<block_q4_0, 8l>`.
+
+Distinct from [`_bare_type_name_cpp`], which additionally strips the template
+arguments. Both spellings are needed and they are not interchangeable: this one
+is looked up in `struct_types` (which is keyed on raw DWARF names, template
+arguments and all), while the stripped one is what a constructor is *named*.
+Conflating them is exactly what made the first draft of the agreement test
+report 26 phantom disagreements on llamacpp's `tensor_traits` instantiations.
+"""
+function _cpp_innermost_scope(cls::AbstractString)::String
+    depth = 0
+    last_sep = 0
+    i = firstindex(cls)
+    n = lastindex(cls)
+    while i <= n
+        c = cls[i]
+        if c == '<'
+            depth += 1
+        elseif c == '>'
+            depth = max(0, depth - 1)
+        elseif depth == 0 && c == ':' && i < n && cls[nextind(cls, i)] == ':'
+            i = nextind(cls, i)
+            last_sep = i
+        end
+        i = nextind(cls, i)
+    end
+    return String(last_sep == 0 ? cls : cls[nextind(cls, last_sep):end])
+end
+
+"""
+    _cpp_this_param(class_name, func_name, struct_types) -> Dict | Nothing
+
+The C++ wrapper's receiver gate: the synthesized `this` parameter for a method
+whose DWARF entry omits it, or `nothing` when no receiver should be added.
+
+**This is the whole gate, in one place.** It used to be inlined in the emission
+loop, which meant the only way to test it was to re-implement it — a third copy
+of a decision that already exists twice, in a codebase whose worst outbreak
+(Dear ImGui, 788 thunks) came from exactly two copies drifting. It is called by
+the emission loop and by `test_symbol_hygiene.jl`, so the test exercises the
+shipping code rather than a paraphrase of it.
+
+The receiver is synthesized when EITHER:
+
+  * the class is a known aggregate — checked under both the raw DWARF spelling
+    (`Box<double>`, which is how `struct_types` is keyed) and the sanitized one
+    (`Box_double`); without the raw check, template-class methods never get a
+    receiver; or
+  * the function is a constructor or destructor, which has one by definition.
+    `struct_types` is NOT a complete list of the library's classes — a
+    .cpp-local polymorphic class gets no type DIE — so box2d's seven internal
+    contact subclasses were emitting zero-argument destructors (2026-08-13).
+
+An unknown class has no emitted Julia type, so the receiver is typed
+`Ptr{Cvoid}` rather than `Ptr{<undeclared name>}`: ABI-identical (both relax to
+`::Any` in the signature, and `_assert_wrapper_loadable` would refuse the
+undeclared spelling if it ever reached a ccall tuple).
+
+Must agree with `FunctionGen._has_receiver` on every input.
+"""
+function _cpp_this_param(class_name::AbstractString, func_name::AbstractString,
+                         struct_types)
+    isempty(class_name) && return nothing
+
+    bare_class = _cpp_innermost_scope(class_name)
+    safe_class = _sanitize_cpp_type_name(bare_class)
+    safe_class = replace(safe_class, r"[^A-Za-z0-9_]" => "")
+    safe_class = replace(safe_class, r"_+"            => "_")
+    safe_class = String(strip(safe_class, '_'))
+    # Garbled (empty, or an operator spelling) — no usable Julia type name.
+    if isempty(safe_class) || startswith(safe_class, "operator")
+        safe_class = "Cvoid"
+    end
+    safe_class == "Cvoid" && return nothing
+
+    known_class = bare_class in struct_types || safe_class in struct_types
+    (known_class || _is_ctor_or_dtor_cpp(class_name, func_name)) || return nothing
+
+    return Dict{String,Any}(
+        "name" => "this",
+        "c_type" => String(class_name) * "*",
+        "julia_type" => known_class ? "Ptr{" * safe_class * "}" : "Ptr{Cvoid}",
+        "position" => 0,
+        "is_synthesized" => true
+    )
+end
+
 function generate_introspective_module_cpp(config::RepliBuildConfig, lib_path::String,
                                       metadata, module_name::String,
                                       registry::TypeRegistry, generate_docs::Bool,
@@ -110,7 +254,38 @@ function generate_introspective_module_cpp(config::RepliBuildConfig, lib_path::S
         f_name = func["name"]
         demangled = func["demangled"]
         params = func["parameters"]
-        
+
+        # A DESTRUCTOR names its own class, and that is authoritative — it does
+        # NOT depend on DWARF having supplied the `this` parameter. This scan
+        # used to infer the class from `params[1]::Ptr{X}`, so when DWARF
+        # stopped describing `this` for destructors the table silently
+        # collapsed and every `Managed`/finalizer built on it vanished:
+        # box2d 30 Managed types → 1, tinyxml2 11 → 2, llamacpp 127 → 18,
+        # measured 2026-08-13 on the first rebuild since July. Same underlying
+        # fact as the receiver gate (`_cpp_this_param`): a destructor has a
+        # receiver by definition, so read the class, not the argument shape.
+        #
+        # The key must be a member of `struct_types` — that was the old
+        # invariant (it came from a `Ptr{X}` whose `X` was checked) and the
+        # rest of the emitter relies on it — so try each spelling and key on
+        # whichever one actually matched.
+        if contains(demangled, "~")
+            cls = String(get(func, "class", ""))
+            if !isempty(cls)
+                inner = _cpp_innermost_scope(cls)
+                sname = inner in struct_types ? inner :
+                        cls   in struct_types ? cls   :
+                        let s = _sanitize_cpp_type_name(inner)
+                            s in struct_types ? s : ""
+                        end
+                if !isempty(sname) && !haskey(deleters, sname)
+                    deleters[sname] = f_name
+                    deleters_mangled[sname] = func["mangled"]
+                end
+            end
+            continue
+        end
+
         # Criteria: 1 arg, arg is Ptr{Struct}, name implies deletion
         if length(params) == 1
             arg_type = params[1]["julia_type"]
@@ -1959,63 +2134,8 @@ function generate_introspective_module_cpp(config::RepliBuildConfig, lib_path::S
             has_this = !isempty(params) && (params[1]["name"] == "this")
             
             if !has_this
-                # Synthesize 'this' parameter.
-                # The class_name may be namespace-qualified (e.g. "pugi::xml_document").
-                # The Julia struct uses only the bare class name without namespace prefix,
-                # so strip everything up to and including the last "::".
-                # Also sanitize template brackets and other non-identifier characters.
-                raw_class = class_name
-                # Remove template parameters before splitting on ::
-                # (so "std::vector<int>" → bare name is "vector" not "vector<int>")
-                bare_class = let
-                    angle_depth = 0
-                    prefix_end = length(raw_class)
-                    for (i, c) in enumerate(raw_class)
-                        if c == '<'; angle_depth += 1
-                        elseif c == '>'; angle_depth = max(0, angle_depth - 1)
-                        end
-                    end
-                    # Find last "::" at angle-bracket depth 0
-                    last_sep = 0
-                    d = 0
-                    i = 1
-                    while i <= length(raw_class) - 1
-                        c = raw_class[i]
-                        if c == '<'; d += 1
-                        elseif c == '>'; d = max(0, d - 1)
-                        elseif c == ':' && raw_class[i+1] == ':' && d == 0
-                            last_sep = i + 1
-                            i += 1
-                        end
-                        i += 1
-                    end
-                    last_sep > 0 ? raw_class[last_sep+1:end] : raw_class
-                end
-                safe_class = _sanitize_cpp_type_name(bare_class)
-                safe_class = replace(safe_class, r"[^A-Za-z0-9_]" => "")
-                safe_class = replace(safe_class, r"_+"            => "_")
-                safe_class = String(strip(safe_class, '_'))
-                # If garbled (empty or looks like an operator), fall back to Cvoid
-                if isempty(safe_class) || startswith(safe_class, "operator")
-                    safe_class = "Cvoid"
-                end
-                
-                # Only synthesize 'this' when the class is a known struct type.
-                # Check both raw DWARF name (bare_class, e.g. "Box<double>") and
-                # sanitized name (safe_class, e.g. "Box_double") since struct_types
-                # contains raw DWARF names. Without checking bare_class, template
-                # class methods never get a 'this' pointer synthesized.
-                # If it's a namespace name (e.g. "pugi") rather than a class, skip.
-                if !isempty(safe_class) && safe_class != "Cvoid" && (bare_class in struct_types || safe_class in struct_types)
-                    this_param = Dict{String,Any}(
-                        "name" => "this",
-                        "c_type" => class_name * "*",
-                        "julia_type" => "Ptr{" * safe_class * "}",
-                        "position" => 0,
-                        "is_synthesized" => true
-                    )
-                    pushfirst!(params, this_param)
-                end
+                this_param = _cpp_this_param(class_name, func_name, struct_types)
+                this_param === nothing || pushfirst!(params, this_param)
             end
         end
 

--- a/src/mlir/JLCSOps.td
+++ b/src/mlir/JLCSOps.td
@@ -72,6 +72,17 @@ def TypeInfoOp : JLCS_Op<"type_info", [Pure, IsolatedFromAbove]> {
 // 2. Generic Field Access Op (Universal Getter)
 def GetFieldOp : JLCS_Op<"get_field", [MemoryEffects<[MemRead]>]> {
   let summary = "Generic operation to read a field from a C-compatible struct.";
+  let description = [{
+    Reads `*(T*)((i8*)structValue + fieldOffset)` — a byte-offset field read
+    against a record whose layout is already known to the producer.
+
+    Producers (`ir_gen/FunctionGen.jl`, `ir_gen/ArrayViewGen.jl`) use it for
+    the thunk argument array, which is exactly such a record: the ciface
+    convention hands the thunk a `void**`, so reading argument slot `i` is a
+    read at byte offset `8*i`. Lowering is a GEP + load, identical machine code
+    to the constant/GEP/load triple it replaces, with the offset stated as an
+    attribute rather than implied by a scaled index.
+  }];
 
   let arguments = (ins
     AnyType:$structValue, // The struct itself (a memory reference or value)
@@ -88,11 +99,25 @@ def GetFieldOp : JLCS_Op<"get_field", [MemoryEffects<[MemRead]>]> {
   let extraClassDeclaration = [{
     GetFieldOp(::mlir::Operation *op) : Op(op) {}
   }];
+
+  // The lowering GEPs structValue as an i8* base; a non-pointer operand or a
+  // negative offset is a producer bug that otherwise surfaces as a bad load.
+  let hasVerifier = 1;
 }
 
 // 3. Generic Field Mutate Op (Universal Setter)
 def SetFieldOp : JLCS_Op<"set_field", [MemoryEffects<[MemWrite]>]> {
   let summary = "Generic operation to write a field into a C-compatible struct.";
+  let description = [{
+    Writes `*(T*)((i8*)structValue + fieldOffset) = newValue` — the mirror of
+    `jlcs.get_field`.
+
+    The producer is `ir_gen/ArrayViewGen.jl`, which builds the `!jlcs.array_view`
+    descriptor (data@0, dims@8, strides@16, rank@24) with one `set_field` per
+    field. That makes the descriptor's layout stated in the same terms the
+    array-op lowering reads it back with (`getStructField` at 0 and 16), instead
+    of a GEP chain on one side and byte offsets on the other.
+  }];
 
   let arguments = (ins
     AnyType:$structValue,  // The struct memory reference
@@ -111,6 +136,9 @@ def SetFieldOp : JLCS_Op<"set_field", [MemoryEffects<[MemWrite]>]> {
   let extraClassDeclaration = [{
     SetFieldOp(::mlir::Operation *op) : Op(op) {}
   }];
+
+  // Same reasoning as GetFieldOp: the lowering GEPs structValue as an i8* base.
+  let hasVerifier = 1;
 }
 
 // ====================================================================
@@ -336,16 +364,36 @@ def DestructorCallOp : JLCS_Op<"dtor_call", [MemoryEffects<[MemRead, MemWrite]>]
     ```mlir
     jlcs.dtor_call @_ZN4BaseD1Ev(%ptr) : (!llvm.ptr) -> ()
     ```
+
+    The producer is `ir_gen/FunctionGen.jl`, which routes a destructor thunk
+    here instead of through `ffe_call`/`try_call`: a destructor is exactly the
+    single-pointer-argument void-return shape this op encodes, so the ABI
+    coercion those ops carry has nothing to do. `jlcs.scope` does NOT produce
+    these — it carries its destructors as a `dtors([...])` symbol list and its
+    own lowering emits the calls, because scope destruction happens at scope
+    *exit*, after the body region.
   }];
 
   let arguments = (ins
     FlatSymbolRefAttr:$callee,    // Mangled destructor symbol
-    AnyType:$obj_ptr              // Object pointer (this)
+    AnyType:$obj_ptr,             // Object pointer (this)
+    // When present, lower as invoke + landing pad rather than a plain call,
+    // with the same sentinel-continue EH model as jlcs.try_call. A destructor
+    // is implicitly noexcept in C++11+, so this is normally absent; the
+    // producer sets it under the same `may_throw && !is_noexcept` rule that
+    // picks try_call over ffe_call, so switching a thunk from try_call to
+    // dtor_call cannot silently drop its landing pad.
+    UnitAttr:$may_throw
   );
 
   let results = (outs);
 
   let assemblyFormat = "$callee `(` $obj_ptr `)` attr-dict `:` `(` type($obj_ptr) `)` `->` `(` `)`";
+
+  // The lowering passes obj_ptr straight to an llvm.call as the `this`
+  // argument; a non-pointer operand produces IR that fails the LLVM verifier
+  // deep inside translation rather than at parse.
+  let hasVerifier = 1;
 }
 
 // ====================================================================

--- a/src/mlir/impl/JLCSOps.cpp
+++ b/src/mlir/impl/JLCSOps.cpp
@@ -5,6 +5,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpImplementation.h"
@@ -176,6 +177,51 @@ LogicalResult TypeInfoOp::verify() {
             return emitOpError() << "vbaseVtableOffsets entries must be "
                                  << "integer attributes, got " << attr;
     return success();
+}
+
+// GetFieldOp / SetFieldOp / DestructorCallOp gained verifiers when they gained
+// producers (2026-08-13). All three lowerings take a pointer operand on faith:
+// get/set_field GEP it as an i8* base, dtor_call passes it as the `this`
+// argument. A non-pointer operand there is accepted by ODS (`AnyType`) and then
+// fails inside LLVM translation with a diagnostic that names neither the op nor
+// the producer that built it.
+
+static LogicalResult verifyPtrOperand(Operation *op, Value v, StringRef what) {
+    if (!isa<LLVM::LLVMPointerType>(v.getType()))
+        return op->emitOpError()
+            << what << " must be an !llvm.ptr — the lowering uses it as a "
+            << "memory base address, so a struct passed by value here cannot "
+            << "work; got " << v.getType();
+    return success();
+}
+
+// A struct field never sits at a negative offset from the struct's own base.
+// (Vtable reads DO address backwards from the address point — that is a
+// different base and a different convention, and it is not what this op
+// models: the vcall lowering reaches its vptr through the getStructField
+// helper directly, not through jlcs.get_field.)
+static LogicalResult verifyFieldOffset(Operation *op, int64_t off) {
+    if (off < 0)
+        return op->emitOpError()
+            << "fieldOffset must be non-negative, got " << off
+            << "; this op addresses forward from a record base";
+    return success();
+}
+
+LogicalResult GetFieldOp::verify() {
+    if (failed(verifyFieldOffset(getOperation(), getFieldOffset())))
+        return failure();
+    return verifyPtrOperand(getOperation(), getStructValue(), "structValue");
+}
+
+LogicalResult SetFieldOp::verify() {
+    if (failed(verifyFieldOffset(getOperation(), getFieldOffset())))
+        return failure();
+    return verifyPtrOperand(getOperation(), getStructValue(), "structValue");
+}
+
+LogicalResult DestructorCallOp::verify() {
+    return verifyPtrOperand(getOperation(), getObjPtr(), "obj_ptr");
 }
 
 LogicalResult MarshalArgOp::verify() {

--- a/src/mlir/impl/JLCSPasses.cpp
+++ b/src/mlir/impl/JLCSPasses.cpp
@@ -1128,10 +1128,81 @@ struct DestructorCallOpLowering : public ConversionPattern {
         auto calleeAttr = dtorOp.getCalleeAttr();
         Value objPtr = adaptor.getObjPtr();
 
-        // Direct call to the destructor symbol — void return, single arg
-        LLVM::CallOp::create(rewriter, 
-            loc, TypeRange(), calleeAttr.getValue(), ValueRange({objPtr}));
+        if (!dtorOp.getMayThrow()) {
+            // Direct call to the destructor symbol — void return, single arg
+            LLVM::CallOp::create(rewriter,
+                loc, TypeRange(), calleeAttr.getValue(), ValueRange({objPtr}));
 
+            rewriter.eraseOp(op);
+            return success();
+        }
+
+        // --- may_throw: direct invoke + landing pad ----------------------
+        // Same sentinel-continue EH model as TryCallOpLowering and the vcall
+        // EH path, and simpler than both: a destructor has no result, so there
+        // is no sentinel slot to allocate and nothing to coerce. The producer
+        // sets may_throw under the same rule that would have picked try_call,
+        // so routing a destructor thunk through this op cannot silently drop
+        // the landing pad it used to get.
+        auto moduleOp = op->getParentOfType<ModuleOp>();
+        auto ptrType = LLVM::LLVMPointerType::get(rewriter.getContext());
+        auto voidType = LLVM::LLVMVoidType::get(rewriter.getContext());
+        auto i32Type = rewriter.getI32Type();
+
+        getOrInsertLLVMFn(moduleOp, rewriter, "__gxx_personality_v0",
+            LLVM::LLVMFunctionType::get(i32Type, {}, true));
+        getOrInsertLLVMFn(moduleOp, rewriter, "__cxa_begin_catch",
+            LLVM::LLVMFunctionType::get(ptrType, {ptrType}, false));
+        getOrInsertLLVMFn(moduleOp, rewriter, "__cxa_end_catch",
+            LLVM::LLVMFunctionType::get(voidType, {}, false));
+        getOrInsertLLVMFn(moduleOp, rewriter, "jlcs_catch_current_exception",
+            LLVM::LLVMFunctionType::get(ptrType, {}, false));
+
+        if (auto llvmFunc = op->getParentOfType<LLVM::LLVMFuncOp>()) {
+            llvmFunc.setPersonalityAttr(
+                FlatSymbolRefAttr::get(rewriter.getContext(), "__gxx_personality_v0"));
+        } else if (auto funcOp = op->getParentOfType<func::FuncOp>()) {
+            funcOp->setAttr("llvm.personality",
+                FlatSymbolRefAttr::get(rewriter.getContext(), "__gxx_personality_v0"));
+        }
+
+        Block* currentBlock = rewriter.getInsertionBlock();
+        auto* parentRegion = currentBlock->getParent();
+        Block* mergeBlock = rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+
+        Block* invokeOkBlock = new Block();
+        parentRegion->getBlocks().insertAfter(currentBlock->getIterator(), invokeOkBlock);
+        Block* catchBlock = new Block();
+        parentRegion->getBlocks().insertAfter(invokeOkBlock->getIterator(), catchBlock);
+
+        rewriter.setInsertionPointToEnd(currentBlock);
+        LLVM::InvokeOp::create(rewriter, loc,
+            /*resultTypes=*/TypeRange{},
+            calleeAttr,
+            ValueRange({objPtr}),
+            invokeOkBlock, /*normalDestOperands=*/ValueRange{},
+            catchBlock, /*unwindDestOperands=*/ValueRange{});
+
+        rewriter.setInsertionPointToEnd(invokeOkBlock);
+        LLVM::BrOp::create(rewriter, loc, ValueRange{}, mergeBlock);
+
+        rewriter.setInsertionPointToEnd(catchBlock);
+        auto lpStructType = LLVM::LLVMStructType::getLiteral(
+            rewriter.getContext(), {ptrType, i32Type}, false);
+        Value nullPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);
+        auto landingPad = LLVM::LandingpadOp::create(rewriter,
+            loc, lpStructType, /*cleanup=*/false, ValueRange{nullPtr});
+        Value exnPtr = LLVM::ExtractValueOp::create(rewriter, loc, ptrType,
+            landingPad, ArrayRef<int64_t>{0});
+        LLVM::CallOp::create(rewriter, loc, TypeRange{ptrType},
+            "__cxa_begin_catch", ValueRange{exnPtr});
+        LLVM::CallOp::create(rewriter, loc, TypeRange{ptrType},
+            "jlcs_catch_current_exception", ValueRange{});
+        LLVM::CallOp::create(rewriter, loc, TypeRange{},
+            "__cxa_end_catch", ValueRange{});
+        LLVM::BrOp::create(rewriter, loc, ValueRange{}, mergeBlock);
+
+        rewriter.setInsertionPointToStart(mergeBlock);
         rewriter.eraseOp(op);
         return success();
     }

--- a/test/mi_test/verify.jl
+++ b/test/mi_test/verify.jl
@@ -150,6 +150,29 @@ using .MiTest
             MiTest.free_base2(pb)
         end
     end
+
+    # ── 5. Adjustor thunks are ABI artifacts, not API ───────────────────────
+    # `_ZThn16_*` exist so a Base2* entry point can subtract 16 and tail-jump
+    # to the Derived method. They carry no DWARF subprogram, so their inferred
+    # "class" is the demangler's phrase ("non-virtual thunk to Derived") — no
+    # aggregate is named that, so neither receiver gate synthesizes `this` and
+    # the wrapper used to emit a zero-argument function calling a method that
+    # needs `this` in rdi. The right path to an override is the vtable or an
+    # explicit upcast, both exercised above.
+    @testset "Adjustor thunks excluded from the API" begin
+        # The fixture must still PRODUCE thunks, or the rest is vacuous.
+        nm_out = read(`nm -g --defined-only $(joinpath(SCRIPT_DIR, "julia", "libmi_test.so"))`, String)
+        @test occursin("_ZThn16_", nm_out)
+
+        thunky(s) = startswith(s, "_ZTh") || startswith(s, "_ZTv") || startswith(s, "_ZTc")
+        fns = JSON.parsefile(joinpath(SCRIPT_DIR, "julia", "compilation_metadata.json"))["functions"]
+        @test !any(thunky(get(f, "mangled", "")) for f in fns)
+
+        wrapper_src = read(wrapper_path, String)
+        @test !occursin("_ZThn", wrapper_src)
+        @test !occursin("thunk to", wrapper_src)
+        @test !any(n -> occursin("thunk_to", String(n)), names(MiTest))
+    end
 end
 
 println("MI_VERIFY_DONE")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,6 +183,14 @@ include(joinpath(@__DIR__, "test_cstring_policy.jl"))
 
 include(joinpath(@__DIR__, "test_introspection.jl"))
 
+# ── Symbol hygiene (no toolchain) ────────────────────────────────────────────
+# Itanium thunk symbols (`_ZTh`/`_ZTv`/`_ZTc`) have no DWARF subprogram, so
+# their "class" is inferred as the demangler's phrase ("non-virtual thunk to
+# Derived") and neither receiver gate gives them `this`. They shipped as
+# exported zero-argument wrappers that SIGSEGV'd on call (2026-08-13).
+
+include(joinpath(@__DIR__, "test_symbol_hygiene.jl"))
+
 # ── Suite wiring guard (no toolchain required) ───────────────────────────────
 # A test file that no suite includes is a test that silently never runs. That
 # is exactly what happened to test_tier1_dispatch.jl: it shipped with the M3

--- a/test/test_jlcs_invariants.jl
+++ b/test/test_jlcs_invariants.jl
@@ -323,4 +323,61 @@ end
     end
 end
 
+# ── E. Producer liveness is DERIVED, not asserted ─────────────────────────────
+#
+# "Defined in TableGen" and "something emits it" are different claims, and the
+# second one rots. It did: after the scope-RAII producer landed, both
+# docs/src/mlir.md and CLAUDE.md credited `jlcs.dtor_call` to FunctionGen for
+# months while nothing under src/ emitted it — FunctionGen builds a
+# `jlcs.scope(...) dtors([...])` and the SCOPE's lowering emits the calls, so
+# DestructorCallOp had a registered, unreachable lowering pattern. Nothing
+# could catch that, because the producer table was prose.
+#
+# So compute it. Read the mnemonics out of JLCSOps.td, grep src/ for emission,
+# and compare against the expected split. Any producer added or lost fails this
+# and names the op — which is the point: the next person to move an op between
+# tiers is told to update the docs instead of discovering the drift later.
+@testset "E. producer liveness matches the recorded split" begin
+    td = read(joinpath(PROJECT, "src", "mlir", "JLCSOps.td"), String)
+    mnemonics = [m.captures[1] for m in eachmatch(r"JLCS_Op<\"([a-z_]+)\"", td)]
+    @test length(mnemonics) == 14
+
+    # Emission sites only: the producers build IR as TEXT, so a mnemonic is
+    # "produced" iff some .jl under src/ writes the string `jlcs.<mnemonic>`.
+    # src/mlir/** is the dialect's own C++/TableGen, not a producer.
+    jl_sources = String[]
+    for (root, _, files) in walkdir(joinpath(PROJECT, "src"))
+        occursin(joinpath("src", "mlir"), root) && continue
+        for f in files
+            endswith(f, ".jl") && push!(jl_sources, read(joinpath(root, f), String))
+        end
+    end
+    corpus = join(jl_sources, "\n")
+    produced = Set(m for m in mnemonics if occursin("jlcs.$m", corpus))
+
+    # dtor_call, get_field and set_field joined this set on 2026-08-13.
+    expected_produced = Set([
+        "type_info", "ffe_call", "try_call", "vcall", "marshal_arg",
+        "marshal_ret", "scope", "ctor_call", "dtor_call", "yield",
+        "load_array_element", "store_array_element", "get_field", "set_field",
+    ])
+    missing_now = sort(collect(setdiff(expected_produced, produced)))
+    extra_now = sort(collect(setdiff(produced, expected_produced)))
+    isempty(missing_now) || println("  → LOST a producer for: ", join(missing_now, ", "))
+    isempty(extra_now) || println("  → GAINED a producer for: ", join(extra_now, ", "))
+    @test isempty(missing_now)
+    @test isempty(extra_now)
+
+    # Every op in the dialect now has a producer. When that stops being true,
+    # this is the line that has to change — together with the table in
+    # docs/src/mlir.md, which is what it exists to keep honest.
+    @test produced == Set(mnemonics)
+
+    # The specific regression that motivated this: dtor_call must be emitted by
+    # FunctionGen, and must NOT be conjured by the scope lowering instead.
+    fg = read(joinpath(PROJECT, "src", "IRGen", "ir_gen", "FunctionGen.jl"), String)
+    @test occursin("jlcs.dtor_call", fg)
+    println("  → all $(length(mnemonics)) dialect ops have a producer under src/")
+end
+
 end # testset

--- a/test/test_jlcs_producers.jl
+++ b/test/test_jlcs_producers.jl
@@ -15,6 +15,15 @@
 #  C. Array-view producer: fixed-size primitive array members get zero-copy
 #     get/set thunks through the strided ops. Verified end-to-end against a
 #     raw Julia buffer.
+#  E. dtor_call producer (2026-08-13): a destructor thunk is exactly the
+#     single-pointer-arg void-return shape jlcs.dtor_call encodes, so it stops
+#     going out as a generic ffe_call/try_call. Includes the Itanium VTT gate.
+#  F. get_field / set_field producers (2026-08-13): thunk argument slots are
+#     fields of the ciface `void**` at byte offset 8*slot, and the ArrayView
+#     descriptor is four fields at 0/8/16/24. Both were previously raw GEP
+#     chains. Pinned by MACHINE-CODE equality against the old spelling — the
+#     LLVM IR differs cosmetically (GEP element type, !dbg numbering), so a
+#     text diff would prove nothing.
 #
 # Requires libJLCS.so + clang++ (devtests tier).
 
@@ -270,10 +279,146 @@ const IR = JLCSIRGenerator.generate_jlcs_ir(EMPTY_VT, METADATA)
                 @test unsafe_load(Ptr{Int64}(qp), 1) == 0
             end
 
+            # ── dtor_call end-to-end ─────────────────────────────────────────
+            # The destructor thunk now goes out as jlcs.dtor_call rather than
+            # try_call. It must still destruct: Grip::~Grip() bumps the tally
+            # by 1, and the may_throw lowering (invoke + landing pad) is the
+            # path actually taken here, since DWARF marks no dtor noexcept.
+            _reset_tally()
+            dgrip = Int64[5]
+            GC.@preserve dgrip begin
+                obj = Ref(Ptr{Cvoid}(pointer(dgrip)))
+                inner = Ptr{Cvoid}[Base.unsafe_convert(Ptr{Cvoid}, obj)]
+                GC.@preserve obj inner begin
+                    args_ref = Ref(Ptr{Cvoid}(pointer(inner)))
+                    ptrs = Ptr{Cvoid}[Base.unsafe_convert(Ptr{Cvoid}, args_ref)]
+                    GC.@preserve args_ref begin
+                        @test jit_invoke(jit, "$(SYM_DTOR)_thunk", ptrs)
+                    end
+                end
+            end
+            @test _tally() == 1
+
             destroy_jit(jit)
-            println("  ✓ scope-RAII + array-view producers execute end-to-end")
+            println("  ✓ scope-RAII + array-view + dtor_call producers execute end-to-end")
         finally
             destroy_context(ctx)
         end
+    end
+
+    @testset "E. dtor_call producer — emission and the VTT arity gate" begin
+        # The destructor thunk carries the op, with may_throw (the module is
+        # C++ and DWARF marks no destructor noexcept, which is the same rule
+        # that used to pick try_call over ffe_call).
+        @test occursin("jlcs.dtor_call @$(SYM_DTOR)(%val_1) { may_throw } : (!llvm.ptr) -> ()", IR)
+        # ...and it is no longer routed through the generic call ops.
+        @test !occursin("try_call %val_1 { callee = @$(SYM_DTOR) }", IR)
+        # Non-destructors are untouched.
+        @test occursin("callee = @$(SYM_CONSUME)", IR)
+
+        FG = RepliBuild.JLCSIRGenerator.FunctionGen
+
+        # THE ARITY GATE. Under Itanium a base-object destructor (D2) of a
+        # class with virtual bases takes a second VTT argument — vi_test has
+        # three of these — and jlcs.dtor_call has no operand to carry it.
+        # Such a destructor must keep the ffe_call/try_call path; converting
+        # it would drop the VTT silently, which is a miscompile, not a
+        # cosmetic difference. Negative-checked below by the paired case.
+        vtt_dtor = Any[Dict{String,Any}(
+            "name" => "~Vb", "mangled" => "_ZN2VbD2Ev",
+            "demangled" => "Vb::~Vb()", "is_method" => true, "class" => "Vb",
+            "parameters" => Any[
+                Dict{String,Any}("name" => "this", "c_type" => "Vb*"),
+                Dict{String,Any}("name" => "vtt",  "c_type" => "void**")],
+            "return_type" => Dict{String,Any}("c_type" => "void"))]
+        vtt_ir = FG.generate_function_thunks(vtt_dtor, GRIP_STRUCTS; may_throw=true)
+        @test !occursin("jlcs.dtor_call", vtt_ir)
+        @test occursin("callee = @_ZN2VbD2Ev", vtt_ir)
+
+        # The same destructor WITHOUT the VTT parameter does convert — so the
+        # exclusion above is the arity, not the name or the class.
+        plain_dtor = Any[Dict{String,Any}(
+            "name" => "~Vb", "mangled" => "_ZN2VbD1Ev",
+            "demangled" => "Vb::~Vb()", "is_method" => true, "class" => "Vb",
+            "parameters" => Any[Dict{String,Any}("name" => "this", "c_type" => "Vb*")],
+            "return_type" => Dict{String,Any}("c_type" => "void"))]
+        plain_ir = FG.generate_function_thunks(plain_dtor, GRIP_STRUCTS; may_throw=true)
+        @test occursin("jlcs.dtor_call @_ZN2VbD1Ev(%val_1) { may_throw }", plain_ir)
+
+        # may_throw tracks the module setting, so a noexcept-clean module gets
+        # the plain-call lowering rather than an invoke it does not need.
+        noeh_ir = FG.generate_function_thunks(plain_dtor, GRIP_STRUCTS; may_throw=false)
+        @test occursin("jlcs.dtor_call @_ZN2VbD1Ev(%val_1) : (!llvm.ptr) -> ()", noeh_ir)
+        @test !occursin("may_throw", noeh_ir)
+    end
+
+    @testset "F. get_field / set_field producers" begin
+        AVG = RepliBuild.JLCSIRGenerator.ArrayViewGen
+
+        # Argument slots are fields of the ciface `void**`: slot i at byte 8i.
+        @test occursin("\"jlcs.get_field\"(%args_ptr) {fieldOffset = 0 : i64} : (!llvm.ptr) -> !llvm.ptr", IR)
+        # The raw spelling this replaced is gone from both producers.
+        @test !occursin("llvm.getelementptr %args_ptr", IR)
+
+        av = AVG.generate_array_view_thunks(GRIP_STRUCTS)
+        @test occursin("\"jlcs.get_field\"(%args_ptr) {fieldOffset = 8 : i64}", av)   # index slot
+        @test occursin("\"jlcs.get_field\"(%args_ptr) {fieldOffset = 16 : i64}", av)  # value slot (set thunk)
+        # ArrayView descriptor built field-by-field, in the same terms the
+        # load/store_array_element lowering reads it back with (data@0,
+        # strides@16 via getStructField in JLCSPasses.cpp).
+        for (off, val) in ((0, "%data"), (8, "%dims"), (16, "%strides"), (24, "%one"))
+            @test occursin("\"jlcs.set_field\"(%view, $(val)) {fieldOffset = $(off) : i64}", av)
+        end
+        @test !occursin("llvm.getelementptr %view", av)
+    end
+
+    @testset "G. get_field / set_field are machine-code identical to raw GEP" begin
+        # The whole justification for moving these producers onto the dialect
+        # is that it changes what the IR SAYS, not what it DOES. Text and even
+        # LLVM IR differ (GEP element type, !dbg numbering); the instructions
+        # must not. Compare the exact shapes the producers emit.
+        function insns(src, tag)
+            ctx = create_context()
+            obj = tempname() * ".o"
+            try
+                mod = parse_module(ctx, src; source_name="equiv_$tag.mlir")
+                @assert lower_to_llvm(mod)
+                RepliBuild.MLIRNative.emit_object(mod, obj)
+                out = String[]
+                for l in split(read(`objdump -d --no-show-raw-insn $obj`, String), '\n')
+                    m = match(r"^\s+[0-9a-f]+:\s+(.*)$", l)
+                    m === nothing && continue
+                    push!(out, replace(strip(m.captures[1]), r"\s+#.*$" => ""))
+                end
+                return out
+            finally
+                rm(obj, force=true); destroy_context(ctx)
+            end
+        end
+        wrap(body) = """
+        module {
+          func.func private @sink(!llvm.ptr)
+          func.func @t(%args_ptr: !llvm.ptr) attributes { llvm.emit_c_interface } {
+        $body
+            return
+          }
+        }
+        """
+        raw_slot = wrap("""
+            %idx_2 = arith.constant 1 : i64
+            %arg_ptr_2 = llvm.getelementptr %args_ptr[%idx_2] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.ptr
+            %val_ptr_2 = llvm.load %arg_ptr_2 : !llvm.ptr -> !llvm.ptr
+            jlcs.ffe_call %val_ptr_2 { callee = @sink } : (!llvm.ptr) -> ()""")
+        new_slot = wrap("""
+            %val_ptr_2 = "jlcs.get_field"(%args_ptr) {fieldOffset = 8 : i64} : (!llvm.ptr) -> !llvm.ptr
+            jlcs.ffe_call %val_ptr_2 { callee = @sink } : (!llvm.ptr) -> ()""")
+        @test insns(raw_slot, "raw_slot") == insns(new_slot, "new_slot")
+
+        raw_store = wrap("""
+            %f = llvm.getelementptr %args_ptr[16] : (!llvm.ptr) -> !llvm.ptr, i8
+            llvm.store %args_ptr, %f : !llvm.ptr, !llvm.ptr""")
+        new_store = wrap("""
+            "jlcs.set_field"(%args_ptr, %args_ptr) {fieldOffset = 16 : i64} : (!llvm.ptr, !llvm.ptr) -> ()""")
+        @test insns(raw_store, "raw_store") == insns(new_store, "new_store")
     end
 end

--- a/test/test_symbol_hygiene.jl
+++ b/test/test_symbol_hygiene.jl
@@ -1,0 +1,290 @@
+# =============================================================================
+# Symbol hygiene — ABI-artifact symbols must never reach the wrappable API
+# =============================================================================
+#
+# `extract_symbols_from_binary` feeds `parse_function_signatures`, which infers
+# a signature from the DEMANGLED STRING for anything DWARF does not describe.
+# That inference is only meaningful for symbols that are actually functions the
+# user could call. Two classes are not:
+#
+#   • `__rb_*` promoted statics (static-promotion pass) — slice-binding surface.
+#   • Itanium thunks (`_ZTh`/`_ZTv`/`_ZTc`) — vtable-slot entry points that
+#     adjust `this` and tail-jump to the real method.
+#
+# Both fail the same way: no DWARF subprogram, so the "class" comes out of the
+# demangled prefix. For a thunk that prefix is the demangler's PHRASE — class
+# `"non-virtual thunk to Derived"` — and no aggregate is named that, so neither
+# receiver gate (`FunctionGen._has_receiver`, `GeneratorCpp`'s `struct_types`
+# check) synthesizes `this`. The wrapper then emits a zero-argument function
+# calling a method that needs `this` in rdi.
+#
+# Not a theoretical hazard: before the filter, `ViTest.virtual_thunk_to_Diamond_tag()`
+# was exported, documented, zero-argument, and SIGSEGV'd on call — the virtual
+# thunk dereferences the garbage `this` twice (`mov (%rdi),%rax` →
+# `mov -0x20(%rax),%rax`) to read the vcall offset out of the vptr. Found
+# 2026-08-13.
+#
+# No toolchain: the predicate is a pure function of two strings, and the
+# fixture-level end-to-end assertions live in mi_test/vi_test verify.jl.
+
+using Test
+import JSON   # runtests.jl loads only Test + RepliBuild; this file needs JSON itself
+
+@testset "Symbol hygiene" begin
+    C = RepliBuild.Compiler
+
+    @testset "Itanium thunk classification" begin
+        # Real thunks, from the MI and VI fixtures' own nm output.
+        for (m, d) in [
+            ("_ZThn16_N7DerivedD0Ev",      "non-virtual thunk to Derived::~Derived()"),
+            ("_ZThn16_N7DerivedD1Ev",      "non-virtual thunk to Derived::~Derived()"),
+            ("_ZThn16_NK7Derived5get_bEv", "non-virtual thunk to Derived::get_b() const"),
+            ("_ZThn16_N7DiamondD0Ev",      "non-virtual thunk to Diamond::~Diamond()"),
+            ("_ZTv0_n24_N4LeftD1Ev",       "virtual thunk to Left::~Left()"),
+            ("_ZTv0_n24_N5RightD0Ev",      "virtual thunk to Right::~Right()"),
+            ("_ZTv0_n32_NK7Diamond3tagEv", "virtual thunk to Diamond::tag() const"),
+        ]
+            @test C._is_itanium_thunk(m, d)
+        end
+
+        # Covariant-return thunks: no fixture produces one, so this is the
+        # synthetic arm. Kept because the grammar admits it and the cost of
+        # missing it is the same SIGSEGV.
+        @test C._is_itanium_thunk("_ZTch0_h0_N1D5cloneEv",
+                                  "covariant return thunk to D::clone()")
+
+        # The demangled phrase alone must classify: `mangled_name` falls back to
+        # the demangled string when the address→mangled lookup misses, and an
+        # ingested binary may carry no mangled form at all.
+        @test C._is_itanium_thunk("virtual thunk to Diamond::tag() const",
+                                  "virtual thunk to Diamond::tag() const")
+
+        # Ordinary methods and free functions must survive. `_ZTV`/`_ZTI`/`_ZTS`
+        # are the OTHER `_ZT*` special names — they are data symbols and never
+        # reach this filter, but a prefix test written as `_ZT` would eat them
+        # AND, more importantly, would be the wrong shape.
+        for (m, d) in [
+            ("_ZNK7Derived5get_bEv", "Derived::get_b() const"),
+            ("_ZN7DerivedD2Ev",      "Derived::~Derived()"),
+            ("_ZTV7Derived",         "vtable for Derived"),
+            ("_ZTI7Derived",         "typeinfo for Derived"),
+            ("_ZTS7Derived",         "typeinfo name for Derived"),
+            ("_ZTT7Diamond",         "VTT for Diamond"),
+            ("b2World_Step",         "b2World_Step"),
+        ]
+            @test !C._is_itanium_thunk(m, d)
+        end
+
+        # A class whose name merely STARTS with a thunk-ish letter sequence is a
+        # normal nested-name encoding (`_ZN` + length + name), not a special
+        # name. This is what makes the `_ZT` prefix safe rather than lucky.
+        @test !C._is_itanium_thunk("_ZN3Thx3fooEv", "Thx::foo()")
+        @test !C._is_itanium_thunk("_ZN3Tvx3barEv", "Tvx::bar()")
+        @test !C._is_itanium_thunk("_ZN9thunk_lib3runEv", "thunk_lib::run()")
+    end
+
+    @testset "the fixtures' own thunk symbols are filtered" begin
+        # Drives the real predicate over the exact symbol set `nm` reports for
+        # the MI/VI fixtures, so the test pins BEHAVIOUR on real input rather
+        # than on hand-written strings. Skips when the fixtures aren't built —
+        # this file runs in the no-toolchain suite.
+        for fixture in ("mi_test", "vi_test")
+            so = joinpath(@__DIR__, fixture, "julia", "lib$(fixture).so")
+            isfile(so) || continue
+            out = try
+                read(`nm -g --defined-only $so`, String)
+            catch
+                continue
+            end
+            code_syms = String[]
+            for line in split(out, '\n')
+                parts = split(strip(line))
+                length(parts) >= 3 && parts[2] in ("T", "W", "t", "w") &&
+                    push!(code_syms, String(parts[3]))
+            end
+            @test !isempty(code_syms)
+
+            thunks = filter(s -> startswith(s, "_ZTh") || startswith(s, "_ZTv"), code_syms)
+            @test !isempty(thunks)                       # fixture still exercises the class
+            @test all(s -> C._is_itanium_thunk(s, s), thunks)
+
+            # And nothing else in the fixture is caught by it.
+            others = filter(s -> !(s in thunks), code_syms)
+            @test !any(s -> C._is_itanium_thunk(s, s), others)
+        end
+    end
+
+    # ── `class` must be a SCOPE, not the demangler's prefix ─────────────────
+    # Itanium mangles a function TEMPLATE's return type into the symbol, so the
+    # demangler prints `bool gguf_reader::read<int>(...)`. `gguf_reader` is a
+    # real class, so the old flat `split(prefix, "::")` produced the scope
+    # `"bool gguf_reader"` — no aggregate is named that, both receiver gates
+    # declined `this`, and every argument shifted one register. That is the
+    # SILENT direction `_has_receiver`'s docstring warns about, and it was live
+    # in the Hub: 62 methods across box2d/llamacpp/pugixml/tinyxml2.
+    #
+    # Every case below is a real demangled name taken from a Hub package or
+    # fixture, not an invented one.
+    @testset "extract_class_name / extract_function_name" begin
+        for (dem, cls, nm) in [
+            # Plain method and free function — the shapes that always worked.
+            ("Calculator::compute(int, int, char)",                  "Calculator",       "compute"),
+            ("sum_vector(std::vector<int, std::allocator<int> > const&)", "",             "sum_vector"),
+            ("Derived::get_b() const",                               "Derived",          "get_b"),
+            ("b2Distance(b2DistanceOutput*, b2SimplexCache*, b2DistanceInput const*)", "", "b2Distance"),
+
+            # Function template: return type is mangled in, and must not become
+            # part of the scope.
+            ("bool gguf_reader::read<signed char>(std::vector<signed char>&, unsigned long) const",
+             "gguf_reader", "read<signed char>"),
+            ("void b2DynamicTree::Query<b2BroadPhase>(b2BroadPhase*, b2AABB const&) const",
+             "b2DynamicTree", "Query<b2BroadPhase>"),
+
+            # Multi-word return type — the cut is the LAST top-level space.
+            ("unsigned long long ImGui::RoundScalarWithFormatT<unsigned long long>(char const*, int, unsigned long long)",
+             "ImGui", "RoundScalarWithFormatT<unsigned long long>"),
+
+            # Return type that is itself `::`-qualified AND template-bearing.
+            ("std::enable_if<std::is_integral<unsigned int>::value, bool>::type llama_model_loader::get_arr_n<unsigned int>(llm_kv, unsigned int&, bool)",
+             "llama_model_loader", "get_arr_n<unsigned int>"),
+
+            # Template ARGUMENTS containing `::` — what broke the flat split.
+            ("bool llama_model_loader::get_arr<std::vector<int, std::allocator<int> > >(llm_kv, std::vector<int, std::allocator<int> >&, bool)",
+             "llama_model_loader", "get_arr<std::vector<int, std::allocator<int> > >"),
+            ("tinyxml2::XMLElement* tinyxml2::XMLDocument::CreateUnlinkedNode<tinyxml2::XMLElement, 120>(tinyxml2::MemPoolT<120>&)",
+             "tinyxml2::XMLDocument", "CreateUnlinkedNode<tinyxml2::XMLElement, 120>"),
+
+            # A cast inside template arguments — paren depth, not just angle.
+            ("void ggml::cpu::repack::gemm<block_q2_K, 8l, 8l, (ggml_type)15>(int, float*, unsigned long, void const*)",
+             "ggml::cpu::repack", "gemm<block_q2_K, 8l, 8l, (ggml_type)15>"),
+
+            # Free FUNCTION template — scope is empty, not a truncated string.
+            ("bool gguf_read_emplace_helper<short>(gguf_reader const&, std::vector<gguf_kv>&)",
+             "", "gguf_read_emplace_helper<short>"),
+
+            # Namespaced classes, nested classes, template classes.
+            ("pugi::xml_document::load_string(char const*, unsigned int)", "pugi::xml_document", "load_string"),
+            ("llama_kv_cache_dsv4_context::comp_plan::operator=(llama_kv_cache_dsv4_context::comp_plan&&)",
+             "llama_kv_cache_dsv4_context::comp_plan", "operator="),
+            ("std::vector<int, std::allocator<int> >::push_back(int const&)",
+             "std::vector<int, std::allocator<int> >", "push_back"),
+
+            # Conversion operators — the ONLY names with a legitimate top-level
+            # space. Cutting at it would eat the name, so they bail unchanged.
+            ("pugi::xml_parse_result::operator bool() const", "pugi::xml_parse_result", "operator bool"),
+        ]
+            @test C.extract_class_name(dem)    == cls
+            @test C.extract_function_name(dem) == nm
+        end
+
+        # ── Relational/arrow operators: SCOPE exact, NAME knowingly ragged ──
+        # `_find_toplevel_paren` tracks `<`/`>` without clamping, so `operator>`
+        # drives it negative and `operator<` drives it positive — either way the
+        # argument list's `(` is never seen at depth 0 and the prefix is never
+        # cut. `_qualified_name_parts` has its own CLAMPED walker, so the scope
+        # is right (these were `"pugi::xml_attribute::operator>=(pugi"` before)
+        # and `this` is synthesized correctly. Only the emitted Julia function
+        # name carries the parameter text, which the generator then sanitizes
+        # the same way it already does for `operator=` → `operatorassign`.
+        #
+        # Deliberately NOT fixed by clamping `_find_toplevel_paren`: measured
+        # over 10,618 Hub names it changes exactly 7 (`operator>`/`>=`/`->`) and
+        # leaves the `operator<`/`<=` siblings ragged, i.e. it would split one
+        # family into two spellings. Uniform beats half-fixed; a real fix skips
+        # the `operator` token outright.
+        for (dem, cls) in [
+            ("pugi::xml_attribute::operator>=(pugi::xml_attribute const&) const", "pugi::xml_attribute"),
+            ("pugi::xml_attribute::operator<(pugi::xml_attribute const&) const",  "pugi::xml_attribute"),
+            ("pugi::xml_node::operator>(pugi::xml_node const&) const",            "pugi::xml_node"),
+            ("pugi::xml_node_iterator::operator->() const",                       "pugi::xml_node_iterator"),
+            # Conversion-to-function-pointer: prefix is cut at the `(` of `(*)`.
+            ("pugi::xml_node::operator void (*)(pugi::xml_node***)() const",      "pugi::xml_node"),
+        ]
+            @test C.extract_class_name(dem) == cls
+            @test startswith(C.extract_function_name(dem), "operator")
+        end
+
+        # Direction invariant: the scope may only ever get MORE precise. A
+        # correct scope is a suffix-preserving refinement of the old one — it
+        # never introduces a name the old answer did not already contain.
+        for dem in ["bool gguf_reader::read<int>(std::vector<int>&, unsigned long) const",
+                    "void b2BroadPhase::UpdatePairs<b2ContactManager>(b2ContactManager*)",
+                    "unsigned int ImGui::RoundScalarWithFormatT<unsigned int>(char const*, int, unsigned int)"]
+            @test occursin(C.extract_class_name(dem), dem)
+        end
+    end
+
+    # ── The two receiver gates must agree ───────────────────────────────────
+    # `FunctionGen._has_receiver` (MLIR thunk) and `GeneratorCpp`'s
+    # `struct_types` check (Julia wrapper) decide the SAME argument array from
+    # opposite ends of the pipeline. When they disagree the thunk reads a slot
+    # the wrapper never wrote — that is the Dear ImGui incident (788 thunked
+    # functions, 174 crashing immediately, 614 with every argument shifted) and
+    # it is the same shape as `ffe_call`/`try_call` each carrying their own SysV
+    # coercion. The code is duplicated on purpose (generator isolation), so
+    # AGREEMENT is what has to be pinned, not the implementation.
+    @testset "Both receiver gates agree" begin
+        FG = RepliBuild.JLCSIRGenerator.FunctionGen
+        W  = RepliBuild.Wrapper
+
+        # ctor/dtor predicate: same verdict from both copies, on both the
+        # obvious shapes and the ones that broke real packages.
+        for (cls, nm, want) in [
+            ("b2CircleContact",                        "~b2CircleContact", true),   # box2d: no type DIE
+            ("Derived",                                "~Derived",         true),
+            ("pugi::xml_document",                     "xml_document",     true),   # namespaced ctor
+            ("Box<double>",                            "Box",              true),   # template class ctor
+            ("std::vector<int, std::allocator<int> >", "vector",           true),
+            ("b2DynamicTree",                          "Query<b2BroadPhase>", false),
+            ("gguf_reader",                            "read<int>",        false),
+            ("ImGui",                                  "GetVersion",       false),  # namespace, free fn
+            ("pugi::xml_node",                         "operator>=",       false),
+            ("",                                       "~Orphan",          false),  # no class ⇒ no verdict
+        ]
+            got_fg = FG._is_ctor_or_dtor(Dict("class" => cls, "name" => nm))
+            got_cpp = W._is_ctor_or_dtor_cpp(cls, nm)
+            @test got_fg == want
+            @test got_cpp == want
+        end
+
+        # Drive BOTH full gates over every Hub package's real metadata and fail
+        # on any function where they disagree. This is the assertion that would
+        # have caught the ImGui incident, the adjustor thunks, and the box2d
+        # destructors — all three were gate disagreements or shared blind spots.
+        hub = joinpath(homedir(), "Desktop", "Projects", "RepliBuild-Hub", "packages")
+        checked = 0
+        disagreements = String[]
+        if isdir(hub)
+            for pkg in readdir(hub)
+                mf = joinpath(hub, pkg, "julia", "compilation_metadata.json")
+                isfile(mf) || continue
+                # Deliberately NOT wrapped in try/catch. The first draft was, and
+                # it swallowed an `UndefVarError: JSON` — every package was
+                # skipped, the sweep proved nothing, and only the `checked`
+                # counter below revealed it. A bare catch around the one call
+                # that loads the corpus can silently turn this whole testset into
+                # a no-op; that is the failure this guard exists to prevent.
+                meta = JSON.parsefile(mf)
+                get(meta, "language", "") in ("c++", "cpp", "cxx") || continue
+                structs = get(meta, "struct_definitions", Dict())
+                # struct_types as GeneratorCpp builds it: the aggregate names.
+                stypes = Set{String}(String(k) for k in keys(structs))
+                for f in get(meta, "functions", [])
+                    get(f, "is_method", false) || continue
+                    cls = String(get(f, "class", ""))
+                    isempty(cls) && continue
+                    checked += 1
+                    fg  = FG._has_receiver(f, structs)
+                    # The REAL GeneratorCpp gate, not a paraphrase of it.
+                    cpp = W._cpp_this_param(cls, String(get(f, "name", "")), stypes) !== nothing
+                    fg == cpp || push!(disagreements,
+                        "$pkg :: $(get(f, "mangled", "?")) class=$(repr(cls)) FunctionGen=$fg GeneratorCpp=$cpp")
+                end
+            end
+        end
+        isempty(disagreements) || @warn "Receiver gates disagree" n=length(disagreements) first=first(disagreements, 5)
+        @test isempty(disagreements)
+        # The sweep must actually have run, or it proves nothing.
+        isdir(hub) && @test checked > 1000
+    end
+end

--- a/test/vi_test/verify.jl
+++ b/test/vi_test/verify.jl
@@ -125,6 +125,33 @@ using .ViTest
             ViTest.free_diamond(pd)
         end
     end
+
+    # ── Adjustor/virtual thunks are ABI artifacts, not API ──────────────────
+    # The diamond produces both forms: `_ZThn16_*` (fixed subtraction) and
+    # `_ZTv0_n24_*` (vcall offset read THROUGH the vptr). Neither carries a
+    # DWARF subprogram, so the inferred "class" is the demangler's phrase
+    # ("virtual thunk to Diamond") and no receiver gate gives them `this`.
+    # `ViTest.virtual_thunk_to_Diamond_tag()` was an exported, documented,
+    # zero-argument function that SIGSEGV'd on call — the virtual form
+    # dereferences the garbage `this` twice before it even reaches the callee.
+    # Correct paths to an override are the vtable and Diamond_as_Right, both
+    # exercised above.
+    @testset "Adjustor thunks excluded from the API" begin
+        # The fixture must still PRODUCE both forms, or the rest is vacuous.
+        nm_out = read(`nm -g --defined-only $(joinpath(SCRIPT_DIR, "julia", "libvi_test.so"))`, String)
+        @test occursin("_ZThn16_", nm_out)
+        @test occursin("_ZTv0_n", nm_out)
+
+        thunky(s) = startswith(s, "_ZTh") || startswith(s, "_ZTv") || startswith(s, "_ZTc")
+        fns = JSON.parsefile(joinpath(SCRIPT_DIR, "julia", "compilation_metadata.json"))["functions"]
+        @test !any(thunky(get(f, "mangled", "")) for f in fns)
+
+        wrapper_src = read(wrapper_path, String)
+        @test !occursin("_ZThn", wrapper_src)
+        @test !occursin("_ZTv0_", wrapper_src)
+        @test !occursin("thunk to", wrapper_src)
+        @test !any(n -> occursin("thunk_to", String(n)), names(ViTest))
+    end
 end
 
 println("VI_VERIFY_DONE")


### PR DESCRIPTION
### `RepliBuild.Debug` — read the emitted code without running anything (2026-08-08)

The gdb path from the entry below needs a live process stopped at exactly the
right moment. This is the same information from a file.

`enableObjectDump` was the one `ExecutionEngineOptions` debug field still at its
default — and `dumpObject` had been a parameter of `jlcs_create_jit`, and of
Julia's `create_jit`, since the JIT was written: threaded all the way down and
then dropped on the floor. The knob read as supported and did nothing. It is now
wired, plus a `jlcs_dump_object` export, so the engine's emitted object can be
written to disk.

`REPLIBUILD_JIT_OBJDUMP` turns it on. The object lands at `<pkg>/.debug/obj/<lib>.o`
beside the generated MLIR, and carries the same DWARF the JIT registers with gdb
— so `objdump -dS` interleaves dialect ops with the machine code they became,
with no debugger involved:

```
  %ret_val = "jlcs.vcall"(%val_1) { slot = 2 : i64, may_throw } : (!llvm.ptr) -> i32
     5db:  48 8b 07           mov    (%rdi),%rax
     5de:  48 8b 40 10        mov    0x10(%rax),%rax
     5ea:  ff d0              call   *%rax
```

The new `RepliBuild.Debug` module reads those artifacts: `thunks`, `mlir_body`,
`disassemble`, `dwarf`, and `walk` (one thunk, both views). It touches no live
state, so it answers about a package this process never built. Source resolution
needs no working directory — `DW_AT_comp_dir` is absolute.

Off unless asked for: the object cache retains every emitted object for the
engine's lifetime. It also cannot be enabled after the fact — MLIR needs the
cache to exist when the engine is created, and engines are cached per library
per process — so the environment is read before the engine exists rather than
offered as an argument nothing on that path could supply, and asking for a dump
without it is a hard error naming the recipe rather than an empty file.

Two things this pins that nothing else would have noticed, because thunks keep
working without them: that the DWARF still points at the generated MLIR, and
that `.debug_info` contains **only** a compile unit — no `DW_TAG_subprogram`, no
variable DIEs. That is what `LineTablesOnly` means here, and it is why `info
locals` and `p %val_1` come back empty in gdb while file and line work perfectly.
Asserted negatively in `test_debug_inspection.jl` (devtests §16, 43 asserts), so
raising `emissionKind` to `Full` announces itself as a failing test.

### JIT'd thunks are debuggable in gdb, at source level (2026-08-08)

Break on a mangled thunk name and gdb stops *inside the emitted MLIR*, by file
and line, with `list` and `disassemble /s` working:

```
Thread 1 "julia" hit Breakpoint 1, _ZNK5Base15get_aEv_thunk () at jlcs_83a242c27fb37885.mlir:126
126	  %val_ptr_1 = llvm.load %arg_ptr_1 : !llvm.ptr -> !llvm.ptr
Producer is MLIR.   Compiled with DWARF 4 debugging format.
```

Three pieces, each small:

- `jlcsModuleCreateParse` takes a `sourceName`. MLIR's parser stamps a
  `FileLineColLoc` naming its buffer onto every op; left unnamed, in-memory text
  gets `-` and the debugger asks for a file that cannot exist. Passing the extra
  argument to an older two-parameter build is harmless under x86-64 SysV, so a
  stale symlinked dialect degrades to unnamed parsing rather than misbehaving.
- `createDIScopeForLLVMFuncOpPass` runs last in the lowering pipeline — it
  operates on `LLVM::LLVMFuncOp`, which only exist after `ConvertFuncToLLVM`. It
  materializes the `DISubprogram` that every `DILocation` needs as a scope.
  Without it the object carries no DWARF at all, and the JIT event listeners
  have nothing to report.
- The module text is written to `<pkg>/.debug/mlir/jlcs_<sha256[1:16]>.mlir` —
  the file those locations point at. It is not diagnostic output, it is the
  debugger's source file. Content-keyed, so re-running a build reuses one path
  instead of accumulating a file per run. It sits beside the wrapper rather than
  in a tempdir so it travels with a vendored one; an unwritable install falls
  back to tempdir, losing co-location rather than the source view.

`clean()` now removes `.debug` alongside `build/` and `julia/`, and it is
gitignored — regenerated at the next JIT init from the module text, so the
capability is self-healing and a tracked copy could only ever be stale.

Two gdb flags are mandatory, not stylistic: `set breakpoint pending on` (the
thunk does not exist until the JIT emits it, so the breakpoint cannot resolve at
load) and `handle SIGSEGV nostop noprint pass` (Julia's GC uses SIGSEGV for
write barriers). `disassemble /s` interleaves dialect ops with the machine code
they became.

What it changes: eightbyte coercion, `byval` vs aggregate splitting, sret buffer
sizing and vtable slot arithmetic move from reasoned to observed. The 2026-08-05
heap smasher (`llama_context_params` emitting 200 bytes against a native 160)
would have been `break` → `finish` → `x/25gx` on the sret buffer.

### perf jitdump is opt-in; it had been writing to `$HOME` unasked (2026-08-08)

MLIR's `ExecutionEngineOptions` defaults **both** JIT listeners on, and
`MLIRExecutionEngine` is linked `--whole-archive`, so nothing in this repo ever
had to ask for it. LLVM hardcodes a `.debug/jit` suffix under `$JITDUMPDIR`,
which was never set — so every JIT'ing process dropped a jitdump in
`$HOME/.debug/jit` with nothing rotating or expiring it. 718 directories /
164 MB had accumulated unnoticed.

The perf listener is now behind `REPLIBUILD_JIT_PROFILE`, read in both places
that matter: the dialect decides whether to register it, and Julia points
`JITDUMPDIR` at `~/.replibuild/jit-sessions/session-<pid>/` (or at the variable's
value, if it looks like a path) before the **first** engine is created — LLVM's
perf listener is a process singleton, so the earliest setting wins. Filing the
dump per package would have been wrong: it is one file per *process* holding
every symbol from every engine, verified by loading two wrapped libraries in one
session and getting a single dump containing both.

The GDB listener stays on unconditionally. It has no filesystem side effects,
and it is what makes the entry above work.