### PR TITLE
Windows port: SysConfigGen's paths, and the export a PE shim never got

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,150 @@ All notable changes to RepliBuild.jl are documented in this file.
 
 ## Unreleased
 
+### First Windows run of the 2026-09-06 Linux work — and the port leftovers it surfaced (2026-09-07)
+
+`julia 1.12.7`, MSYS2 CLANG64, system LLVM/MLIR **22.1.8**, `libJLCS.dll` present.
+The STL half of that work was already correct here; the SysConfigGen half was
+not, and nothing about it raised.
+
+**SysConfigGen compared '/' paths against '\' ones and said no to every one.**
+`capture_config`'s new classification and layout are the first code in that
+module to *depend* on the path spelling rather than merely tolerate it, and its
+two sources disagree on Windows: `compile_commands.json`, which cmake always
+writes '/'-separated, and `walkdir`/`relpath`/`abspath`, which answer in the
+host separator. Every comparison silently returned false.
+
+- **The real generated TU was classified as try_compile scratch and dropped.**
+  `compiled_gen` is keyed on the build-relative path off the compile line
+  ('/'), `gen_sources` on the walk ('\'), so the set difference put *every*
+  generated source in `scratch_sources`. On the cmake fixture `gen_table.c` —
+  which the target compiles — was skipped by the capture and left out of
+  `[compile] source_files`. The library would have linked without it.
+- **`_is_cmake_internal` matched nothing**, so cmake's own
+  `CMakeFiles/<ver>/CompilerIdC/CMakeCCompilerId.c` reached the classifier.
+- **`_build_include_roots` and `_translate_includes` returned empty.**
+  `abspath` spells the separator natively on one side of a `startswith` whose
+  other side is '/'-joined. `include_roots` came out `[""]` instead of
+  `["include", ""]`, so `:auto` collapsed to the build-tree layout and a header
+  included as `<fixt/fixt_config.h>` landed where `-Iconfig` cannot resolve it
+  — precisely the defect the layout work exists to fix.
+- **`_rel_source` returned absolute paths, and that HUNG the process.**
+  `_collapse_excludes` walks `dirname` until it is `""`, but `dirname` is
+  idempotent at a filesystem root — `"C:\\"`, and `"/"` on POSIX — so the loop
+  only ever terminated for a relative path. The suite spun a core with no
+  output and no error. It now stops at the fixed point whatever it is handed,
+  which closes the latent POSIX case with it.
+
+Fixed at ONE seam rather than a branch per site: `_posix` normalizes wherever a
+host path enters the module, and is `Sys.iswindows()`-keyed for the same reason
+`Compiler._canon_path` is — a backslash is a legal POSIX filename character.
+`_rel_source` and `_translate_includes` join through `_join_rel` rather than
+`joinpath`, since their results are matched against `config_rel * "/"`
+downstream — and `_join_rel` keeps `joinpath`'s empty-prefix behaviour
+deliberately: `cmake_probe` defaults `clone_rel` to `""`, where a bare
+`a * "/" * b` yields an ABSOLUTE path. Windows
+now returns the Linux answers exactly on the cmake fixture: `generated_sources`
+`["gen_table.c"]`, `scratch_sources` `["PROBE_TEST/ltest.c"]`, `include_roots`
+`["include", ""]`, target files `["a.c", "b.c", "config/gen_table.c"]`.
+`test_sysconfiggen.jl` **61/61**, the same count as Linux.
+
+**The STL force-ctor fix is right on Windows; its assertions were libstdc++'s
+spelling of it.** libc++ emits standalone `vector[abi:nqe220108]()` /
+`map[abi:nqe220108]()` at `-O2` and `extract_stl_method_symbols` binds exactly
+one constructor per container, the default one — the fix works as built. What
+was red is the `-O2` emission probe: three `nm` regexes written without libc++'s
+inline namespace (`std::__1::`) or its `_LIBCPP_HIDE_FROM_ABI` tag, and two
+`full_signature` equalities against the untagged spelling. Restated as
+invariants — optional inline namespace, optional `[abi:...]`, tag stripped
+before comparing which ctor bound. Same lesson as `_canon_path`: a test that
+states one host's answer instead of the invariant goes red on the other for a
+correct build.
+
+`_classify_stl_method`'s iterator guard had that shape in the CODE, not the
+test: libc++ spells vector's iterator `__wrap_iter`, which `r"iterator"i` does
+not match, so Windows bound `erase`/`insert` overloads Linux drops. Benign
+today — only `CppMap.delete!` reads an `erase` thunk, and map's libc++ iterator
+is `__map_iterator`, which the old guard does catch (verified against a real
+`-O2` build, not assumed) — but the hosts now bind the same set instead of
+resting on that. `test_stl_extract.jl` **56/56**.
+
+**`[wrap.macros]` produced nothing on Windows, because `visibility("default")`
+is not how PE exports.** Found by taking SysConfigGen past its own tests: a
+pcre2 harvested and built entirely on Windows came out with **14 shims defined
+by `nm -g` and 0 in the export directory**, which is the list the wrapper reads
+on PE — so every `PCRE2_*` constant was missing from the module and 23 of the
+package's 24 failures were `UndefVarError: PCRE2_CASELESS` and friends.
+Reduced: `visibility("default")` and `__declspec(dllexport)` both DEFINE a
+symbol in a PE, and only the second exports it. The shim TU now carries
+`RB_SHIM_EXPORT`, keyed on `_WIN32` — the compiler's target decides, not the
+host running RepliBuild — with the ELF spelling unchanged (it is load-bearing
+there for `-fvisibility=hidden` projects like box2d3).
+
+That fix alone would have been a worse bug than the one it closed. **A
+`dllexport` anywhere turns mingw's auto-export off for the WHOLE image**, so
+adding ours to a library that exports nothing explicitly ERASES its API:
+measured on a two-function probe DLL, the export table went from
+`{lib_a, lib_b, shim}` to `{shim}` — the wrapper would then emit the constants
+and nothing else, with no error anywhere. `create_library` now asks
+`_pe_export_intent` whether anything OTHER than a shim is `dllexport`ed,
+reading it off the IR (LLVM prints the linkage beside the symbol name, so one
+pass answers it, and it works on the LTO path where a filename test would not).
+When ours are the only explicit exports it hands back `-Wl,--export-all-symbols`
+— which is exactly what the auto-export default expands to, CRT still excluded
+by ld's own list, so the link produces the set it always would have.
+
+Measured both shapes on Windows:
+- pcre2 (exports explicitly, via `PCRE2_EXP_DECL`) — export table **78 API +
+  14 shims, zero CRT**; no `--export-all-symbols`, so its chosen surface is
+  untouched. `packages/pcre2/test.jl` went **39 pass / 8 fail / 16 error →
+  76 / 1 / 0**, the one remaining failure being the suite's own
+  `endswith(lib, "libpcre2.so")`, i.e. Linux's file extension.
+- a library exporting nothing of its own — all three symbols exported and all
+  three wrapped, including the shim.
+
+Guarded twice, both toolchain-free: the emission split in
+`test_c_generator_policies.jl` (including a count, so one un-marked shim is a
+failure rather than one silently missing constant), and `_pe_export_intent`'s
+three decisions in `test_windows_port.jl`.
+
+**Two port leftovers, both `/dev/null`-class, both older than this work:**
+
+- **`test_win64_abi.jl` skipped on the only host that can execute the rules it
+  pins.** Its oracle probe ran `clang --target=... -o /dev/null`, and `run` does
+  not go through a shell, so clang got the literal path and resolved it as
+  `\dev\null`. The probe concluded a CLANG64 clang "cannot target
+  x86_64-w64-windows-gnu" — its own host — and the file `@test_skip`ped.
+  Writing to a real temp file instead: **95/95 on Windows**, up from one skip.
+  The table encoded on Linux as a specification is now checked against clang on
+  a machine that can run it.
+- **`test_jlcs_invariants.jl` §D ran `nm -D` on a PE**, which is a hard error
+  ("File format has no dynamic symbol table"), not an empty answer — the same
+  fact the port already recorded for the wrapper's three export sites, at a
+  fourth site nobody converted. Nor is there anything for it to find: PE binds
+  every symbol at link time, so a DLL still carrying an unresolved
+  `mlir::jlcs::` reference cannot link. The RTLD_NOW probe above it is the whole
+  check on Windows and is the stronger half. **16/16**, was 16 + 1 error.
+
+**Still red on Windows, and NOT from this work — each confirmed identical at
+`ddd2d7f` (the commit before the pull), fixtures and all:**
+
+- `test_struct_abi` **28/2** — §A wants `!llvm.struct<packed (i64)>` in emitted
+  IR; §C's B3 `{long,long,long}` trace returns `(0x8_00000007, 0xFFFFFFFF_00000009, 4)`
+  where it wants `(7, 8, 9)`. The bit pattern is three 32-bit values read as
+  64-bit, so this smells like the LLP64 `long` split the port already named —
+  but the fixture is hand-written MLIR at `i64`, so it is a lowering question,
+  not a width table one. Byte-identical at baseline.
+- `test_c_inprocess` **9/1** — the `[link] fallback = true` escape hatch writes
+  `#dbg_declare(...)` into `*_opt.ll` and the tool it then shells to rejects it
+  (`expected instruction opcode`). Debug-record vs intrinsic textual IR across
+  the two-LLVM boundary; the in-process path (the default) is green.
+- `test_debug_inspection` **47/1** — "object capture round trip".
+- `callback_test/test_exceptions.jl` aborts standalone with `0xC00000FF`, and
+  `devtests.jl` still dies at `libunwind: pc not in table` after §4 with zero
+  test failures. Same known SEH/COFF unwind-registration class already recorded
+  under **Open on Windows**; running each remaining section in its own process
+  is the way around it, and all of them were run that way for this entry.
+
 ### `capture_config` tells try_compile scratch from library code, and keeps a generated header's include form (2026-09-06)
 
 Two defects in `SysConfigGen.capture_config`, both surfaced harvesting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -751,6 +751,25 @@ has the setup and the full findings; these are the ones that bite a code change.
   read `objdump -p` on PE. `GetProcAddress` consults only that directory, so it
   is the strongest available authority. `nm -D` on a PE is a hard error, not an
   empty answer. Measured: c_test 115 nm / 28 exports, stl_test 691/513.
+- **GETTING INTO THAT DIRECTORY IS OPT-IN, AND `visibility("default")` IS NOT
+  HOW.** Both it and `__declspec(dllexport)` DEFINE the symbol in a PE; only
+  the second exports it. `[wrap.macros]` shims carried the ELF spelling alone,
+  so on Hub pcre2 all 14 were defined by `nm -g` and 0 were in the export
+  directory — every constant silently absent from the module. `RB_SHIM_EXPORT`
+  in `generate_macro_shims` now emits both, keyed on `_WIN32` (the COMPILER's
+  target decides, not the host). Keep the ELF branch: it is load-bearing for
+  `-fvisibility=hidden` projects like box2d3.
+- **...AND ONE `dllexport` TURNS AUTO-EXPORT OFF FOR THE WHOLE IMAGE.** mingw
+  exports everything (minus the CRT, by ld's own exclusion list) only while
+  NOTHING is explicitly exported, so adding a `dllexport`ed shim to a library
+  that exports nothing of its own ERASES its API — a two-function probe DLL
+  goes from `{lib_a, lib_b, shim}` to `{shim}`, and the wrapper then emits the
+  constants and nothing else, with no error. `create_library` asks
+  `_pe_export_intent` whether anything but a shim is exported and hands back
+  `-Wl,--export-all-symbols` only when ours are the only ones — that flag IS
+  the auto-export default, so it reproduces the same set rather than inventing
+  one. Never pass it unconditionally: a library that exports deliberately
+  (pcre2's `PCRE2_EXP_DECL`) would publish every internal symbol instead.
 - **The C bucket needs a sysroot on Windows.** `Clang_unified_jll` already
   targets `x86_64-w64-windows-gnu` — the triple was never the problem — but it
   is a bare compiler artifact with no headers and no CRT. `_c_bucket_sysroot()`
@@ -820,12 +839,47 @@ has the setup and the full findings; these are the ones that bite a code change.
   Linux while green on Windows. Drive the pattern list with pre-canonicalised
   spellings so it runs everywhere; assert canonicalisation as
   `== Sys.iswindows()`.
+- **EVERY PATH IN `SysConfigGen` IS '/'-SEPARATED, and `_posix` is where that
+  is made true.** The module compares two path sources that disagree on
+  Windows: `compile_commands.json`, which cmake always writes with forward
+  slashes, and `walkdir`/`relpath`/`abspath`, which answer in the host
+  separator. Every pattern in the file — `_is_cmake_internal`, `_capture_rel`,
+  `_collapse_excludes`, `toml_fragment`'s `config_rel * "/"` — is written
+  against the '/' spelling, so before the seam existed each comparison silently
+  returned false and **a real generated TU was classified as try_compile
+  scratch and dropped from `[compile] source_files`**. Normalize at the point a
+  host path ENTERS the module, never at the comparison; join with `"/"` rather
+  than `joinpath` for anything matched downstream. `Sys.iswindows()`-keyed for
+  the same reason `_canon_path` is. Related: `dirname` is idempotent at a
+  filesystem root, so a `while` that walks to `""` only terminates on a
+  RELATIVE path — `_collapse_excludes` spun a core when handed an absolute one.
+- **`/dev/null` is not a path on Windows.** `run` does not go through a shell,
+  so a tool receives the literal string and resolves it as `\dev\null`.
+  `test_win64_abi.jl`'s oracle probe used it and concluded that a CLANG64 clang
+  cannot target `x86_64-w64-windows-gnu` — its own host — so the one test that
+  pins the Win64 ABI table `@test_skip`ped on the only machine able to check
+  it (95/95 once it writes to a temp file instead). Grep for `/dev/null` in
+  anything reached by `run`; `devnull` as a *stream* redirect is fine.
 - **Open on Windows:** `libunwind: pc not in table` aborts the `devtests.jl`
   parent after the callback fixture in some runs (zero test failures in every
   run; needs prior in-parent JIT activity, so it points at SEH unwind-table
-  registration for ORC-JIT'd frames on COFF). `test_abi_nested.jl` still states
-  the SysV XMM expectation — latent, it passes today. **PE inverts the export
-  model** (`dllexport` opt-in vs ELF exporting by default), which is a design
+  registration for ORC-JIT'd frames on COFF). Run each remaining section in its
+  own process to get past it — `callback_test/test_exceptions.jl` standalone
+  aborts the same way (`0xC00000FF`), which places the fault in that fixture's
+  JIT/EH activity rather than in the suite driver. `test_abi_nested.jl` still
+  states the SysV XMM expectation — latent, it passes today (14/14).
+  `test_struct_abi` is **28/2**: §A wants `!llvm.struct<packed (i64)>` in the
+  emitted IR, and §C's B3 `{long,long,long}` try_call trace returns three
+  32-bit values read as 64-bit (`0x8_00000007`, …) instead of `(7, 8, 9)` — the
+  fixture is hand-written MLIR at `i64`, so it is a lowering question, not a
+  width-table one. `test_c_inprocess` is **9/1**: only the `[link] fallback =
+  true` escape hatch, which writes `#dbg_declare(...)` into `*_opt.ll` and then
+  shells to a tool that rejects it (`expected instruction opcode`) — the
+  in-process default path is green. `test_debug_inspection` is **47/1**
+  ("object capture round trip"). All four verified identical at `ddd2d7f`, so
+  none of them came from the 2026-09-06 SysConfigGen/STL work. **PE inverts the
+  export model** (`dllexport` opt-in vs ELF exporting by default): handled for
+  `[wrap.macros]` shims (see the two export bullets above), still a design
   problem for `__rb_*` static promotion — deferred, since that is quarantined
   Tier 1 and no shipped package takes it.
 

--- a/src/Builder/Compiler.jl
+++ b/src/Builder/Compiler.jl
@@ -1236,6 +1236,41 @@ end
 # =============================================================================
 
 """
+    _pe_export_intent(ir_files) -> (; saw_shim, saw_foreign_export)
+
+Who, if anyone, asked for an explicit PE export.
+
+On PE a DLL keeps mingw's auto-export only while NOTHING is explicitly
+exported; one `dllexport` anywhere switches the whole image to explicit-only.
+`generate_macro_shims` emits `__declspec(dllexport)` on Windows — it has to, or
+no shim reaches the export directory — which makes RepliBuild capable of
+erasing the API of a library that exports nothing of its own. This is the
+question that decides.
+
+Read off the IR rather than guessed: `dllexport` is a linkage specifier LLVM
+prints on the defining line, beside the symbol name, so one pass settles both
+"is anything exported" and "is it only ours". Covers the LTO path too, where
+every TU has already been merged into one module and a filename test would not.
+"""
+function _pe_export_intent(ir_files::Vector{String})
+    saw_shim = false
+    saw_foreign_export = false
+    for f in ir_files
+        isfile(f) || continue
+        for line in eachline(f)
+            is_shim = occursin("replibuild_shim_", line)
+            is_shim && (saw_shim = true)
+            if occursin("dllexport", line) && !is_shim
+                saw_foreign_export = true
+            end
+            (saw_shim && saw_foreign_export) &&
+                return (; saw_shim, saw_foreign_export)
+        end
+    end
+    return (; saw_shim, saw_foreign_export)
+end
+
+"""
 Create shared library from LLVM IR.
 Returns path to library file.
 """
@@ -1267,6 +1302,27 @@ function create_library(config::RepliBuildConfig, ir_files::Union{String,Vector{
     ]
     append!(cmd_args, files)
     append!(cmd_args, ["-o", lib_path])
+
+    # A dllexport ANYWHERE turns mingw's auto-export off for the WHOLE image,
+    # and the macro-shim TU carries one on Windows now. For a library that
+    # exports nothing explicitly and relies on that default, ours alone would
+    # therefore ERASE its API: measured on a two-function probe DLL, the export
+    # table went from {lib_a, lib_b, shim} to {shim}. `--export-all-symbols` is
+    # what the auto-export default expands to, so asking for it back reproduces
+    # exactly the set the link would have produced anyway — the CRT stays out,
+    # excluded by ld's own list, which is the property _pe_exported_names
+    # depends on.
+    #
+    # Only when WE are the ones introducing the dllexport. A library that
+    # already exports explicitly (pcre2, via PCRE2_EXP_DECL) keeps the surface
+    # it chose and the shims simply join it; forcing the flag there would
+    # publish every internal symbol instead.
+    if Sys.iswindows()
+        intent = _pe_export_intent(files)
+        if intent.saw_shim && !intent.saw_foreign_export
+            push!(cmd_args, "-Wl,--export-all-symbols")
+        end
+    end
 
     # Add library search paths
     for dir in config.link.link_dirs
@@ -1851,6 +1907,30 @@ function generate_macro_shims(config::RepliBuildConfig, cpp_files::Vector{String
         end
         println(io, "")
 
+        # A shim has to reach the wrapper's function list, and the two object
+        # formats name DIFFERENT mechanisms for that.
+        #
+        #   ELF — `visibility("default")` is load-bearing: a project built with
+        #   `-fvisibility=hidden` (box2d3) turns every shim local otherwise, and
+        #   the wrapper's `nm -g --defined-only` list loses all of them.
+        #
+        #   PE — export is OPT-IN and `visibility("default")` is INERT for it.
+        #   The shim was defined in the DLL and absent from the export
+        #   directory, which is the list the wrapper reads on Windows
+        #   (_pe_exported_names), so every `[wrap.macros]` entry silently
+        #   vanished from the generated module. Measured on Hub pcre2: 14 shims
+        #   defined by `nm -g`, 0 exported, 0 wrapped.
+        #
+        # Keyed on `_WIN32` rather than `Sys.iswindows()` because it is the
+        # COMPILER's target that decides, not the host running RepliBuild.
+        # `used` survives LTO internalization on both.
+        println(io, "#if defined(_WIN32)")
+        println(io, "#  define RB_SHIM_EXPORT __attribute__((used)) __declspec(dllexport)")
+        println(io, "#else")
+        println(io, "#  define RB_SHIM_EXPORT __attribute__((used, visibility(\"default\")))")
+        println(io, "#endif")
+        println(io, "")
+
         for (macro_name, def) in config.wrap.macros
             ret_type = get(def, "ret", "void")
             args = get(def, "args", String[])
@@ -1864,12 +1944,8 @@ function generate_macro_shims(config::RepliBuildConfig, cpp_files::Vector{String
                 push!(arg_names, pname)
             end
             
-            # Shims must stay in the .so's export table: the wrapper's function
-            # list comes from `nm -g --defined-only`, and projects built with
-            # -fvisibility=hidden (e.g. box2d3) would otherwise turn every shim
-            # local — silently dropping all [wrap.macros]. `used` additionally
-            # survives LTO internalization.
-            sig = "__attribute__((used, visibility(\"default\"))) $ret_type replibuild_shim_$macro_name($(join(param_strs, ", ")))"
+            # RB_SHIM_EXPORT — see the per-format reasoning above the loop.
+            sig = "RB_SHIM_EXPORT $ret_type replibuild_shim_$macro_name($(join(param_strs, ", ")))"
             println(io, "$sig {")
 
             # If "args" key is present → function-like macro, emit MACRO(args...)
@@ -2069,10 +2145,19 @@ function _classify_stl_method(method_sig::String, container_type::String="")::Un
         # (_Rb_tree_rebalance_for_erase). The paren-aware split made these
         # visible; they used to be dropped because `std::_Rb_tree_iterator`
         # stole the class/method `::`.
-        occursin(r"iterator"i, sig) && return nothing
+        #
+        # BOTH standard libraries' spellings, or the guard is Linux-only:
+        # libstdc++ writes `__normal_iterator` / `_Rb_tree_iterator`, libc++
+        # writes vector's as `__wrap_iter` — no "iterator" anywhere in it. map
+        # is caught either way (libc++'s is `__map_iterator`), so only vector
+        # diverged, and only into a thunk nothing currently calls; match both
+        # so the two hosts bind the same set rather than resting on that.
+        (occursin(r"iterator"i, sig) || occursin("__wrap_iter", sig)) && return nothing
         return ("erase", false)
     elseif startswith(sig, "insert(")
-        occursin(r"iterator"i, sig) && return nothing
+        # Same two spellings as erase above — libc++'s vector iterator is
+        # `__wrap_iter`, which `r"iterator"i` does not see.
+        (occursin(r"iterator"i, sig) || occursin("__wrap_iter", sig)) && return nothing
         return ("insert", false)
     elseif startswith(sig, "find(")
         return ("find", is_const)

--- a/src/Builder/SysConfigGen.jl
+++ b/src/Builder/SysConfigGen.jl
@@ -231,6 +231,30 @@ const _SOURCE_EXTS = (".c", ".cpp", ".cc", ".cxx")
 
 _has_ext(path, exts) = lowercase(splitext(path)[2]) in exts
 
+# EVERY PATH THIS MODULE COMPARES, SPLITS OR STORES IS '/'-SEPARATED. The compile
+# lines come out of compile_commands.json, which cmake always writes with forward
+# slashes, and every pattern here is written against that spelling —
+# `_is_cmake_internal`, `_capture_rel`, `_collapse_excludes`, `toml_fragment`'s
+# `config_rel * "/"`. `walkdir`/`relpath`/`abspath` answer in the HOST separator,
+# so on Windows the two spellings never meet and every comparison silently says
+# "no": a real generated TU was classified as try_compile scratch and dropped
+# from `[compile] source_files`, cmake's own CompilerIdC probe was NOT dropped,
+# `_build_include_roots` and `_translate_includes` both returned empty, and
+# `_rel_source` handed absolute paths downstream. None of it raised.
+#
+# HOST-CONDITIONAL on purpose, the same reason `Compiler._canon_path` is: a
+# backslash is a legal character in a POSIX filename, so rewriting one off
+# Windows would corrupt a real name.
+_posix(p::AbstractString) = Sys.iswindows() ? replace(String(p), '\\' => '/') : String(p)
+
+# `joinpath`, but always '/'-separated (see `_posix`) and keeping joinpath's
+# empty-prefix behaviour: `cmake_probe` defaults `clone_rel` to `""`, and
+# `"" * "/" * "lib"` is an ABSOLUTE path, which is not what a clone-relative
+# name means. Used wherever the result is matched against a '/'-joined prefix
+# downstream, which `joinpath` would spell natively on one side only.
+_join_rel(a::AbstractString, b::AbstractString) =
+    isempty(a) ? String(b) : string(a, "/", b)
+
 # cmake writes its own scaffolding into the build tree: compiler-identification
 # probe sources under CMakeFiles/, and whatever FetchContent pulled into _deps/.
 # Both match the extension whitelist below, and neither is ours to capture.
@@ -242,7 +266,7 @@ function _walk_generated(build_dir::String)
     headers, sources = String[], String[]
     for (root, _, files) in walkdir(build_dir)
         for f in files
-            rel = relpath(joinpath(root, f), build_dir)
+            rel = _posix(relpath(joinpath(root, f), build_dir))
             _is_cmake_internal(rel) && continue
             _has_ext(f, _HEADER_EXTS) && push!(headers, rel)
             _has_ext(f, _SOURCE_EXTS) && push!(sources, rel)
@@ -309,7 +333,7 @@ function _rel_source(file::String, source_dir::String, build_dir::String,
     if startswith(file, source_dir * "/")
         return file[length(source_dir)+2:end]
     elseif startswith(file, build_dir * "/")
-        return joinpath(config_rel, _capture_rel(file[length(build_dir)+2:end], roots))
+        return _join_rel(config_rel, _capture_rel(file[length(build_dir)+2:end], roots))
     end
     return file
 end
@@ -346,13 +370,13 @@ function _translate_includes(sig::Vector{String}, source_dir::String,
                              clone_rel::String)
     out = String[]
     for dir in _include_dirs(sig)
-        ad = rstrip(abspath(dir), '/')
+        ad = rstrip(_posix(abspath(dir)), '/')
         mapped = if ad == build_dir || startswith(ad, build_dir * "/")
             config_rel                      # generated headers travel with the package
         elseif ad == source_dir
             ""                              # the clone root; the resolver adds this
         elseif startswith(ad, source_dir * "/")
-            joinpath(clone_rel, ad[length(source_dir)+2:end])
+            _join_rel(clone_rel, ad[length(source_dir)+2:end])
         else
             continue                        # system / external dep, not ours to pin
         end
@@ -374,7 +398,7 @@ end
 function _build_include_roots(dirs, build_dir::String)
     roots = String[]
     for d in dirs
-        ad = rstrip(abspath(d), '/')
+        ad = rstrip(_posix(abspath(d)), '/')
         r = if ad == build_dir
             ""
         elseif startswith(ad, build_dir * "/")
@@ -393,13 +417,10 @@ end
 # no evidence about the include form, so it degrades to the historical basename
 # rather than to a new wrong answer.
 #
-# Both sides are '/'-separated, which this module has assumed since it was
-# written (`_is_cmake_internal`, `_rel_source`). On Windows the roots come from
-# compile_commands.json, which cmake normalizes to '/', while `rel` comes from
-# `walkdir` + `relpath`, which does not — so no root matches and every file takes
-# the basename branch, i.e. exactly the pre-2026-09-06 behaviour. Safe, not
-# right; a fix belongs in `_walk_generated` and must be `Sys.iswindows()`-keyed,
-# since a backslash is a legal character in a POSIX filename.
+# Both sides are '/'-separated — see `_posix`, which is where that is now made
+# true on Windows rather than assumed. Until 2026-09-07 `rel` reached here in the
+# host separator while the roots came '/'-spelled out of compile_commands.json,
+# so no root ever matched and every file silently took the basename branch.
 function _capture_rel(rel::String, roots::Vector{String})
     for r in roots
         isempty(r) && return rel
@@ -414,7 +435,7 @@ function _tree_sources(source_dir::String)
         filter!(d -> d != ".git", dirs)
         for f in files
             _has_ext(f, _SOURCE_EXTS) || continue
-            push!(out, relpath(joinpath(root, f), source_dir))
+            push!(out, _posix(relpath(joinpath(root, f), source_dir)))
         end
     end
     return sort!(out)
@@ -469,7 +490,7 @@ function cmake_probe(source_dir::String;
                      clone_rel::String="",
                      use_llvm_env::Bool=true)
 
-    source_dir = String(rstrip(abspath(source_dir), '/'))
+    source_dir = String(rstrip(_posix(abspath(source_dir)), '/'))
     isdir(source_dir) || error("cmake_probe: source dir not found: $source_dir")
     isfile(joinpath(source_dir, "CMakeLists.txt")) ||
         error("cmake_probe: no CMakeLists.txt in $source_dir — not a cmake project. " *
@@ -477,7 +498,7 @@ function cmake_probe(source_dir::String;
 
     isempty(name) && (name = basename(source_dir))
     isempty(build_dir) && (build_dir = mktempdir(; prefix="rbcapture_$(name)_"))
-    build_dir = String(rstrip(abspath(build_dir), '/'))
+    build_dir = String(rstrip(_posix(abspath(build_dir)), '/'))
     ispath(build_dir) && rm(build_dir; recursive=true, force=true)
     mkpath(build_dir)
 
@@ -518,7 +539,7 @@ function cmake_probe(source_dir::String;
             tgt = _target_of(e, eargs)
             isempty(tgt) && (tgt = "unknown")
             sig = _flag_signature(eargs)
-            afile = abspath(file)
+            afile = _posix(abspath(file))
             startswith(afile, build_dir * "/") &&
                 push!(compiled_gen, afile[length(build_dir)+2:end])
             # Union across every target, not just main_target: a generated header
@@ -667,7 +688,7 @@ function capture_config(probe::CMakeProbe, out_dir::String;
         println(io, "points at. Under `layout=:auto` they keep the include form upstream")
         println(io, "compiles with, so `-I` on this directory resolves them unchanged.\n")
         for w in written
-            println(io, "- `$(relpath(w, out_dir))`")
+            println(io, "- `$(_posix(relpath(w, out_dir)))`")
         end
         if !isempty(probe.scratch_sources)
             println(io, "\n## Skipped — generated, but no target compiles them\n")
@@ -734,7 +755,14 @@ function _collapse_excludes(compiled::Vector{String}, uncompiled::Vector{String}
         while true
             push!(live, d)
             isempty(d) && break
-            d = dirname(d)
+            # `dirname` is idempotent at a filesystem root — "/" on POSIX,
+            # "C:\\" on Windows — so `isempty` alone only terminates for a
+            # RELATIVE path. Everything here is meant to be relative; when a
+            # caller upstream failed to relativize, this spun the CPU forever
+            # instead of saying so. Stop at the fixed point either way.
+            parent = dirname(d)
+            parent == d && break
+            d = parent
         end
     end
 

--- a/test/test_c_generator_policies.jl
+++ b/test/test_c_generator_policies.jl
@@ -192,14 +192,24 @@ end
         @test isempty(badcfg.wrap.cstring_owned)
     end
 
-    @testset "macro shims: default visibility" begin
+    @testset "macro shims: exported on both object formats" begin
         files = RepliBuild.Compiler.generate_macro_shims(cfg, String[])
         @test length(files) == 1
         shim_txt = read(files[1], String)
-        # Both macros forced into the export table (nm -g is the wrapper's
-        # symbol source; -fvisibility=hidden would otherwise drop them)
-        @test occursin("__attribute__((used, visibility(\"default\"))) int replibuild_shim_SYNTH_OK()", shim_txt)
-        @test occursin("__attribute__((used, visibility(\"default\"))) int replibuild_shim_synth_init(void* arg0, int arg1)", shim_txt)
+        # One shim, two mechanisms, because the formats disagree about what
+        # export MEANS. ELF exports by default and wants visibility("default")
+        # only to survive -fvisibility=hidden (box2d3); PE exports nothing
+        # unless asked and treats visibility() as inert, so a merely-defined
+        # shim never reaches _pe_exported_names — the list the wrapper reads on
+        # Windows — and the constant silently disappears from the module.
+        @test occursin("#if defined(_WIN32)", shim_txt)
+        @test occursin("#  define RB_SHIM_EXPORT __attribute__((used)) __declspec(dllexport)", shim_txt)
+        @test occursin("#  define RB_SHIM_EXPORT __attribute__((used, visibility(\"default\")))", shim_txt)
+        @test occursin("RB_SHIM_EXPORT int replibuild_shim_SYNTH_OK()", shim_txt)
+        @test occursin("RB_SHIM_EXPORT int replibuild_shim_synth_init(void* arg0, int arg1)", shim_txt)
+        # EVERY shim carries it, not just the two named above: one shim missing
+        # the marker is one constant missing from the wrapper, with no error.
+        @test count("RB_SHIM_EXPORT", shim_txt) == 2 + length(cfg.wrap.macros)
         # Value macro emits the bare name; function-like macro forwards args
         @test occursin("return SYNTH_OK;", shim_txt)
         @test occursin("return synth_init(arg0, arg1);", shim_txt)

--- a/test/test_jlcs_invariants.jl
+++ b/test/test_jlcs_invariants.jl
@@ -314,7 +314,15 @@ end
     # member function mangles as `_ZNK`, so an `_ZN4mlir4jlcs` filter reports 8
     # of the 10 real offenders and silently drops both `ArrayViewType`
     # accessors — one of the two classes this probe exists for.
-    if Sys.which("nm") !== nothing
+    #
+    # ELF only. `nm -D` reads the DYNAMIC symbol table, which a PE does not
+    # have: it is a hard error ("File format has no dynamic symbol table"),
+    # not an empty answer, so on Windows this errored the testset instead of
+    # cross-checking anything. Nor is there anything here to find — PE binds
+    # every symbol at link time, so a DLL still carrying an unresolved
+    # `mlir::jlcs::` reference cannot link at all. The RTLD_NOW probe above is
+    # the whole of this check on Windows, and it is the stronger half.
+    if !Sys.iswindows() && Sys.which("nm") !== nothing
         syms = readlines(`nm -D --undefined-only $lib`)
         undef = filter(s -> occursin("4mlir4jlcs", s), syms)
         isempty(undef) || println("  → undefined jlcs symbols:\n    ",

--- a/test/test_stl_extract.jl
+++ b/test/test_stl_extract.jl
@@ -90,6 +90,16 @@ end
     @test C._classify_stl_method(
         "erase(std::__detail::_Node_iterator<std::pair<int const, int>, false, false>)",
         "std::unordered_map<int, int>") === nothing
+    # libc++ spells vector's iterator `__wrap_iter` — no "iterator" in the name,
+    # so a `r"iterator"i` test alone is a guard that only holds on libstdc++.
+    @test C._classify_stl_method(
+        "erase(std::__1::__wrap_iter<int const*>)", "std::vector<int>") === nothing
+    @test C._classify_stl_method(
+        "erase(std::__1::__map_iterator<std::__1::__tree_iterator<int, void*, long long>>)",
+        "std::map<int, int>") === nothing
+    # ...and the key overload, the one CppMap.delete! actually calls, still binds
+    # under either spelling.
+    @test C._classify_stl_method("erase(int const&)", "std::map<int, int>") == ("erase", false)
 
     # Bucket begin/end(size_type) is not iterator begin/end().
     @test C._classify_stl_method("end() const", "std::map<int, int>") == ("end_", true)
@@ -121,6 +131,11 @@ end
 # Negative check from GENERATOR-stl-force-default-ctor.md: a templates-only
 # package at -O2, no user `T t;`, must still have standalone vector() / map()
 # and extract must bind them as constructor.
+
+# `full_signature` keeps the raw demangled text, and on libc++ that carries the
+# ABI tag `_classify_stl_method` strips before it decides anything. The tag is
+# not part of the method's identity, so drop it before asserting which ctor bound.
+_untag(sig::AbstractString) = replace(sig, r"\[abi:[^\]]*\]" => "")
 
 function _clangxx_available()::Bool
     try
@@ -171,9 +186,14 @@ end
 
         nm_out, nm_ec = RepliBuild.BuildBridge.execute("nm", ["-gC", "--defined-only", lib])
         @test nm_ec == 0
-        @test occursin(r"std::vector<int.*::vector\(\)", nm_out)
-        @test occursin(r"std::map<int, int.*::map\(\)", nm_out)
-        @test occursin(r"std::map<int, int.*::~map\(\)", nm_out)
+        # Spelled as an invariant, not as one standard library's answer: libc++
+        # puts an inline namespace on the class (`std::__1::vector`) and mangles
+        # a `_LIBCPP_HIDE_FROM_ABI` tag in after the method name
+        # (`vector[abi:nqe220108]()`), so a libstdc++-shaped literal goes red on
+        # Windows for a build that is in fact correct.
+        @test occursin(r"std::(?:__\w+::)?vector<int.*::vector(?:\[abi:[^\]]*\])?\(\)", nm_out)
+        @test occursin(r"std::(?:__\w+::)?map<int, int.*::map(?:\[abi:[^\]]*\])?\(\)", nm_out)
+        @test occursin(r"std::(?:__\w+::)?map<int, int.*::~map(?:\[abi:[^\]]*\])?\(\)", nm_out)
 
         methods = C.extract_stl_method_symbols(lib, ["std::vector<int>", "std::map<int, int>"])
         @test haskey(methods, "std::vector<int>")
@@ -181,11 +201,11 @@ end
 
         vctors = [m for m in methods["std::vector<int>"] if m["method"] == "constructor"]
         @test length(vctors) == 1
-        @test vctors[1]["full_signature"] == "vector()"
+        @test _untag(vctors[1]["full_signature"]) == "vector()"
 
         mctors = [m for m in methods["std::map<int, int>"] if m["method"] == "constructor"]
         @test length(mctors) == 1
-        @test mctors[1]["full_signature"] == "map()"
+        @test _untag(mctors[1]["full_signature"]) == "map()"
 
         @test any(m -> m["method"] == "destructor", methods["std::map<int, int>"])
     end

--- a/test/test_sysconfiggen.jl
+++ b/test/test_sysconfiggen.jl
@@ -217,7 +217,10 @@ else
 
         out = mktempdir()
         written = SCG.capture_config(probe, out)
-        rel = sort(map(w -> relpath(w, out), written))
+        # `written` are real filesystem paths, so they come back in the host
+        # separator; the layout under test is the '/'-spelled one. Assert the
+        # layout, not the host's punctuation.
+        rel = sort(map(w -> SCG._posix(relpath(w, out)), written))
 
         # (2) Layout: nested where the include form is nested, flat where it is
         # flat, in the same capture.

--- a/test/test_win64_abi.jl
+++ b/test/test_win64_abi.jl
@@ -32,7 +32,13 @@ const CAN_TARGET_WIN = CLANG === nothing ? false : try
     mktempdir() do d
         p = joinpath(d, "probe.c")
         write(p, "int f(void){return 0;}\n")
-        success(`$CLANG --target=$TRIPLE -S -emit-llvm -o /dev/null $p`)
+        # A real output file, not /dev/null: `run` does not go through a
+        # shell, so clang receives the literal path and resolves it on
+        # Windows as `\dev\null`, which is not a directory. The probe then
+        # reported that a CLANG64 clang "cannot target x86_64-w64-windows-gnu"
+        # — its own host — and this file, the one test that pins the Win64
+        # rules, skipped on the only machine that can execute them.
+        success(`$CLANG --target=$TRIPLE -S -emit-llvm -o $(joinpath(d, "probe.ll")) $p`)
     end
 catch
     false

--- a/test/test_windows_port.jl
+++ b/test/test_windows_port.jl
@@ -205,4 +205,47 @@ const LE = RepliBuild.LLVMEnvironment
             @test occursin("jlcs_catch_current_exception", err)
         end
     end
+
+    @testset "a shim's dllexport must not cost the library its auto-export" begin
+        # PE keeps mingw's auto-export only while NOTHING is explicitly
+        # exported; one `dllexport` anywhere flips the whole image to
+        # explicit-only. The macro shims now carry one (they must — see
+        # generate_macro_shims), so a library that exports nothing of its own
+        # needs `--export-all-symbols` handed back or its entire API leaves the
+        # export directory, which is the list the wrapper reads on Windows.
+        # Measured on a two-function probe DLL: {lib_a, lib_b, shim} → {shim}.
+        #
+        # `_pe_export_intent` is the decision and it reads IR text, so drive it
+        # with IR text — no compiler, and the assertions hold on either host.
+        mktempdir() do dir
+            shim = joinpath(dir, "shim.ll")
+            write(shim, "define dllexport i32 @replibuild_shim_X() {\n  ret i32 8\n}\n")
+            plain = joinpath(dir, "plain.ll")
+            write(plain, "define i32 @lib_a() {\n  ret i32 1\n}\n")
+            explicit = joinpath(dir, "explicit.ll")
+            write(explicit, "define dso_local dllexport ptr @pcre2_code_copy_8(ptr %0) {\n  ret ptr %0\n}\n")
+
+            # Ours is the only export → auto-export has to be restored.
+            i1 = C._pe_export_intent([plain, shim])
+            @test i1.saw_shim
+            @test !i1.saw_foreign_export
+
+            # The library exports on its own account → leave the surface it
+            # chose alone; forcing the flag would publish every internal.
+            i2 = C._pe_export_intent([explicit, shim])
+            @test i2.saw_shim
+            @test i2.saw_foreign_export
+
+            # No shims → nothing introduced, nothing to decide.
+            i3 = C._pe_export_intent([plain])
+            @test !i3.saw_shim
+            @test !i3.saw_foreign_export
+
+            # A dllexport on the shim's own line is OURS, not the library's —
+            # the whole point of matching per line rather than per file.
+            i4 = C._pe_export_intent([shim])
+            @test i4.saw_shim
+            @test !i4.saw_foreign_export
+        end
+    end
 end


### PR DESCRIPTION
First Windows run of the 2026-09-06 SysConfigGen/STL work, plus the port leftovers and one shipped-feature gap it surfaced. Nothing here raised on its own; every defect returned a wrong answer quietly.

SysConfigGen compared '/' paths against '\' ones and said no to all of them. compile_commands.json is always '/'-separated; walkdir/relpath/abspath answer in the host separator. So a real generated TU was classified as try_compile scratch and dropped from [compile] source_files, _is_cmake_internal matched nothing, _build_include_roots and _translate_includes returned empty, and _rel_source handed absolute paths to _collapse_excludes -- which walks dirname to "" and therefore never terminated, spinning a core with no output. Fixed at one seam (_posix, Sys.iswindows()-keyed for the same reason _canon_path is) plus _join_rel for the joins matched against config_rel downstream; the dirname loop now stops at the fixed point, closing the latent POSIX case with it. test_sysconfiggen.jl 61/61, the Linux count. A pcre2 harvest done entirely on Windows reproduces the checked-in layout, with config.h differing in exactly three correct host probes.

[wrap.macros] produced nothing on Windows. visibility("default") defines a symbol in a PE without exporting it, and the export directory is the list the wrapper reads -- pcre2 had 14 shims defined by nm -g and 0 exported, so every constant was missing from the module. Shims now carry RB_SHIM_EXPORT, keyed on _WIN32 because the compiler's target decides, not the host. That alone would have been worse than the bug it closes: one dllexport turns mingw's auto-export off for the whole image, erasing the API of any library that exports nothing of its own (measured: a two-function probe DLL goes from {lib_a, lib_b, shim} to {shim}). create_library asks _pe_export_intent whether anything but a shim is exported, reading it off the IR so the LTO path is covered too, and restores --export-all-symbols only when ours are the only explicit exports. pcre2 test.jl 39 pass/8 fail/16 error -> 76/1/0; export table 78 API + 14 shims, zero CRT.

The STL force-ctor fix was already correct here; only its assertions were libstdc++'s spelling of it. Restated as invariants -- optional inline namespace, optional [abi:...] tag. _classify_stl_method's iterator guard had the same shape in the CODE: libc++ spells vector's iterator __wrap_iter, which r"iterator"i does not match, so Windows bound erase/insert overloads Linux drops. Both spellings now. test_stl_extract.jl 56/56.

Two leftovers, both /dev/null-class, both older than this work. test_win64_abi probed clang with -o /dev/null, which run() passes literally and Windows resolves as \dev\null, so the one test pinning the Win64 ABI table skipped on the only host able to check it -- 95/95 now, up from one skip. test_jlcs_invariants section D ran nm -D on a PE, a hard error; the property cannot exist there (PE binds every symbol at link time) and the RTLD_NOW probe above it is the stronger check -- 16/16.

Still red on Windows and NOT from this work, each confirmed identical at ddd2d7f with fixtures in place: test_struct_abi 28/2, test_c_inprocess 9/1, test_debug_inspection 47/1, and devtests.jl aborting at "libunwind: pc not in table" after section 4. Running each section in its own process gets past that, and is how every figure above was measured.


Claude-Session: https://claude.ai/code/session_01K3nWb3bE9Pz79yMz2jxuid